### PR TITLE
Add testing scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ npm install
 npm run dev
 ```
 
+### Tests
+
+#### Backend
+```bash
+cd backend
+pytest
+```
+
+#### Frontend
+```bash
+npm test
+```
+
 ## 🔐 Comptes de Démonstration
 
 ### SuperAdmin (Contrôle total)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import pytest
+from backend.app import create_app
+
+@pytest.fixture
+def client():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    app = create_app()
+    app.config.update(TESTING=True)
+    return app.test_client()

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,11 @@
+
+def test_health_endpoint(client):
+    resp = client.get('/api/health')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['status'] == 'healthy'
+
+
+def test_login_failure(client):
+    resp = client.post('/api/auth/login', json={'email': 'admin@pointflex.com', 'password': 'wrong'})
+    assert resp.status_code == 401

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -32,6 +33,12 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.2",
+    "@types/jest": "^29.5.5",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/src/components/AttendanceChart.test.tsx
+++ b/src/components/AttendanceChart.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import AttendanceChart from './AttendanceChart';
+
+test('renders chart title', () => {
+  const data = [{ date: '01/01', present: 1, late: 0, absent: 0 }];
+  render(<AttendanceChart data={data} title="Test Chart" />);
+  expect(screen.getByText('Test Chart')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add pytest suite for backend routes
- wire up Jest with a simple React test
- document how to run tests

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864692e1374833282759eb7ed7c43aa