### PR TITLE
Add profile export route

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Company (Entreprises)
 - `GET /api/attendance` - Historique pointages
 - `GET /api/attendance/stats` - Statistiques personnelles
 
+#### Profil
+- `GET /api/profile` - Informations profil
+- `PUT /api/profile` - Mettre à jour le profil
+- `PUT /api/profile/password` - Changer le mot de passe
+- `GET /api/profile/export` - Exporter les données utilisateur
+
 ## 🔧 Configuration
 
 ### Paramètres Entreprise

--- a/backend/routes/profile_routes.py
+++ b/backend/routes/profile_routes.py
@@ -112,3 +112,29 @@ def change_password():
         print(f"Erreur lors du changement de mot de passe: {e}")
         db.session.rollback()
         return jsonify(message="Erreur interne du serveur"), 500
+
+@profile_bp.route('/export', methods=['GET'])
+@jwt_required()
+def export_profile_data():
+    """Exporte les données de l'utilisateur et ses pointages."""
+    try:
+        current_user = get_current_user()
+        if not current_user:
+            return jsonify(message="Utilisateur non trouvé"), 401
+
+        from models.pointage import Pointage
+
+        pointages = Pointage.query.filter_by(user_id=current_user.id).order_by(
+            Pointage.date_pointage
+        ).all()
+
+        export_data = {
+            'user': current_user.to_dict(include_sensitive=True),
+            'pointages': [p.to_dict() for p in pointages]
+        }
+
+        return jsonify(export_data), 200
+
+    except Exception as e:
+        print(f"Erreur lors de l'export du profil: {e}")
+        return jsonify(message="Erreur interne du serveur"), 500


### PR DESCRIPTION
## Summary
- expose a new `GET /api/profile/export` endpoint in the backend
- document profile endpoints in the README

## Testing
- `python -m pytest -q backend/tests` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646fbde29083328d117b1864a9821b