### PR TITLE
Fix pointage init error

### DIFF
--- a/backend/models/pointage.py
+++ b/backend/models/pointage.py
@@ -44,10 +44,14 @@ class Pointage(db.Model):
     
     def __init__(self, **kwargs):
         """Initialisation avec calcul automatique du statut"""
+        # S'assurer que les valeurs par défaut sont appliquées
+        kwargs.setdefault('heure_arrivee', datetime.utcnow().time())
+        kwargs.setdefault('date_pointage', datetime.utcnow().date())
+
         super(Pointage, self).__init__(**kwargs)
-        
+
         # Calculer le statut si pas défini
-        if not hasattr(self, 'statut') or not self.statut:
+        if not getattr(self, 'statut', None):
             self.calculate_status()
     
     def calculate_status(self):


### PR DESCRIPTION
## Summary
- initialize date and time defaults before calculating status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865125a97a483329e4e14ada4fa0bfb