### PR TITLE
Configure frontend API base URL from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # Copy this to .env and update with your values
 
 # Frontend Configuration
+# VITE_API_URL is used by the frontend to configure the API base URL
 VITE_API_URL=http://localhost:5000/api
 
 # Backend Configuration

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import toast from 'react-hot-toast'
 
 export const api = axios.create({
-  baseURL: '/api',
+  baseURL: import.meta.env.VITE_API_URL || '/api',
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Summary
- let the frontend API client use `import.meta.env.VITE_API_URL` with a `/api` fallback
- clarify in `.env.example` that `VITE_API_URL` is consumed by the frontend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686538b9ab7883329ebd145cbe739c17