### PR TITLE
Add authentication, attendance and frontend tests

### DIFF
--- a/backend/tests/test_attendance.py
+++ b/backend/tests/test_attendance.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+def login_employee(client):
+    resp = client.post('/api/auth/login', json={'email': 'employee@pointflex.com', 'password': 'employee123'})
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def test_office_checkin(client):
+    token = login_employee(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    data = {'coordinates': {'latitude': 48.8566, 'longitude': 2.3522}}
+    resp = client.post('/api/attendance/checkin/office', json=data, headers=headers)
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body['pointage']['type'] == 'office'
+
+
+def test_get_attendance_stats(client):
+    token = login_employee(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    client.post('/api/attendance/checkin/office', json={'coordinates': {'latitude': 48.8566, 'longitude': 2.3522}}, headers=headers)
+    resp = client.get('/api/attendance/stats', headers=headers)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'stats' in data

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+def test_login_success(client):
+    resp = client.post('/api/auth/login', json={'email': 'admin@pointflex.com', 'password': 'admin123'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'token' in data
+
+
+def test_get_current_user(client):
+    login_resp = client.post('/api/auth/login', json={'email': 'admin@pointflex.com', 'password': 'admin123'})
+    token = login_resp.get_json()['token']
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.get('/api/auth/me', headers=headers)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['user']['email'] == 'admin@pointflex.com'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/components/shared/LoadingSpinner.test.tsx
+++ b/src/components/shared/LoadingSpinner.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import LoadingSpinner from './LoadingSpinner';
+
+test('displays optional text', () => {
+  render(<LoadingSpinner text="Loading" />);
+  expect(screen.getByText('Loading')).toBeInTheDocument();
+});

--- a/src/pages/History.test.tsx
+++ b/src/pages/History.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import History from './History';
+
+jest.mock('../services/api', () => ({
+  attendanceService: {
+    getAttendance: jest.fn().mockResolvedValue({ data: { records: [] } })
+  }
+}));
+
+test('renders history page title', async () => {
+  render(<History />);
+  await waitFor(() => expect(screen.getByText('Historique des pointages')).toBeInTheDocument());
+});


### PR DESCRIPTION
## Summary
- add backend tests for auth and attendance routes
- add Jest tests for `LoadingSpinner` component and History page
- enable coverage reporting for Jest

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686538cb471083329d937a4326957b03