### PR TITLE
Add realtime notifications via SSE

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
+from flask_sse import sse
 import os
 
 # Import configuration
@@ -37,6 +38,10 @@ def create_app():
     
     # Initialize database
     db.init_app(app)
+
+    # SSE configuration
+    app.config['REDIS_URL'] = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+    app.register_blueprint(sse, url_prefix='/stream')
     
     # Initialize middleware
     init_auth_middleware(app, jwt)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==1.0.0
 marshmallow==3.20.1
 werkzeug==2.3.7
 bcrypt==4.0.1
+Flask-SSE==0.2.1

--- a/backend/utils/notification_utils.py
+++ b/backend/utils/notification_utils.py
@@ -2,6 +2,7 @@
 
 from models.notification import Notification
 from database import db
+from flask_sse import sse
 
 
 def send_notification(user_id: int, message: str) -> Notification:
@@ -9,5 +10,6 @@ def send_notification(user_id: int, message: str) -> Notification:
     notification = Notification(user_id=user_id, message=message)
     db.session.add(notification)
     db.session.commit()
+    sse.publish(notification.to_dict(), type='notification', channel=f'user_{user_id}')
     print(f"📣 Notification for user {user_id}: {message}")
     return notification

--- a/src/components/RealtimeNotifications.tsx
+++ b/src/components/RealtimeNotifications.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Bell, X, CheckCircle, AlertTriangle, Info, Clock } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
 import { notificationService } from '../services/api'
+import { useNotificationStream } from '../hooks/useNotificationStream'
 
 interface Notification {
   id: string
@@ -39,6 +40,21 @@ export default function RealtimeNotifications() {
 
     loadNotifications()
   }, [])
+
+  useNotificationStream(user?.id, (data: any) => {
+    setNotifications(prev => [
+      ...prev,
+      {
+        id: String(data.id),
+        type: 'info' as const,
+        title: 'Notification',
+        message: data.message,
+        timestamp: new Date(data.created_at),
+        read: false,
+      },
+    ])
+    setUnreadCount(prev => prev + 1)
+  })
 
   const markAsRead = (id: string) => {
     setNotifications(prev => 

--- a/src/hooks/useNotificationStream.ts
+++ b/src/hooks/useNotificationStream.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import toast from 'react-hot-toast'
+
+interface NotificationData {
+  id: number
+  message: string
+  [key: string]: any
+}
+
+export function useNotificationStream(userId?: number, onMessage?: (data: NotificationData) => void) {
+  useEffect(() => {
+    if (!userId) return
+
+    const source = new EventSource(`/stream?channel=user_${userId}`)
+    const handler = (event: MessageEvent) => {
+      try {
+        const data: NotificationData = JSON.parse(event.data)
+        toast.success(data.message)
+        onMessage && onMessage(data)
+      } catch (e) {
+        console.error('Failed to parse notification', e)
+      }
+    }
+
+    source.addEventListener('notification', handler)
+
+    return () => {
+      source.close()
+    }
+  }, [userId, onMessage])
+}


### PR DESCRIPTION
## Summary
- add **Flask-SSE** dependency and initialise it in the backend app
- publish notifications to the SSE channel
- implement `useNotificationStream` hook for the frontend
- display toasts and update state on incoming notifications

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*
- `python -c "import app; print('Backend imports successfully')"` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_686538dfbdcc8332bb9e245d12430aea