### PR TITLE
Fix invoice serialization before commit

### DIFF
--- a/backend/routes/superadmin_routes.py
+++ b/backend/routes/superadmin_routes.py
@@ -371,6 +371,7 @@ def extend_subscription(company_id):
             due_date=datetime.utcnow().date(),
         )
         db.session.add(invoice)
+        db.session.flush()  # ensure defaults like dates are populated
 
         log_user_action(
             action='CREATE_INVOICE',


### PR DESCRIPTION
## Summary
- ensure invoice defaults (including timestamps) exist before logging

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68654d3e92308332b98ab63bc19704ab