### PR TITLE
Fix undefined fields in organization data

### DIFF
--- a/src/pages/EmployeeManagement.tsx
+++ b/src/pages/EmployeeManagement.tsx
@@ -333,7 +333,13 @@ export default function EmployeeManagement() {
   const loadOrganizationData = async () => {
     try {
       const response = await adminService.getOrganizationData()
-      setOrganizationData(response.data)
+      // Ensure all keys exist to avoid undefined access
+      setOrganizationData({
+        departments: response.data.departments || [],
+        services: response.data.services || [],
+        positions: response.data.positions || [],
+        managers: response.data.managers || []
+      })
     } catch (error) {
       console.error('Erreur lors du chargement des données organisationnelles:', error)
     }

--- a/src/pages/OrganizationManagement.tsx
+++ b/src/pages/OrganizationManagement.tsx
@@ -140,8 +140,14 @@ export default function OrganizationManagement() {
       const [orgDataResponse] = await Promise.all([
         adminService.getOrganizationData()
       ])
-      
-      setOrganizationData(orgDataResponse.data)
+
+      // Normalize missing keys to avoid undefined errors
+      setOrganizationData({
+        departments: orgDataResponse.data.departments || [],
+        services: orgDataResponse.data.services || [],
+        positions: orgDataResponse.data.positions || [],
+        managers: orgDataResponse.data.managers || []
+      })
       
       if (activeTab === 'departments') {
         const deptResponse = await adminService.getDepartments()


### PR DESCRIPTION
## Summary
- normalize organization data when loading
- apply same fix in OrganizationManagement page

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68655f88ae588332bf33d4ceb1b406ee