### PR TITLE
Add ESLint config for React/TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ pytest
 #### Frontend
 ```bash
 npm test
+npm run lint  # analyse le code avec ESLint
 ```
 
 ## 🔐 Comptes de Démonstration

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,30 @@
+import js from '@eslint/js';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true }
+      }
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      ...reactRefresh.configs.recommended.rules
+    }
+  }
+];


### PR DESCRIPTION
## Summary
- configure ESLint for React/TypeScript in `eslint.config.js`
- document how to run `npm run lint`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a6bbef788332aa435185b6a68498