### PR TITLE
Add backend and frontend test coverage

### DIFF
--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -1,0 +1,11 @@
+from backend.tests.test_reports import login_admin
+
+
+def test_get_employees(client):
+    token = login_admin(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.get("/api/admin/employees", headers=headers)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'employees' in data
+    assert any(emp['email'] == 'employee@pointflex.com' for emp in data['employees'])

--- a/backend/tests/test_stripe_service.py
+++ b/backend/tests/test_stripe_service.py
@@ -1,0 +1,53 @@
+import types
+import pytest
+from backend.services import stripe_service
+
+class Invoice:
+    def __init__(self, id, amount, company_id):
+        self.id = id
+        self.amount = amount
+        self.company_id = company_id
+
+def test_create_checkout_session(monkeypatch):
+    captured = {}
+
+    class FakeSession:
+        @staticmethod
+        def create(**kwargs):
+            captured['kwargs'] = kwargs
+            return {'id': 'sess_123'}
+
+    fake_stripe = types.SimpleNamespace(checkout=types.SimpleNamespace(Session=FakeSession))
+    monkeypatch.setattr(stripe_service, 'stripe', fake_stripe)
+
+    invoice = Invoice(1, 10.5, 2)
+    session = stripe_service.create_checkout_session(invoice, 'ok', 'ko')
+    assert session == {'id': 'sess_123'}
+    assert captured['kwargs']['metadata']['invoice_id'] == 1
+    assert captured['kwargs']['metadata']['company_id'] == 2
+    assert captured['kwargs']['line_items'][0]['price_data']['unit_amount'] == 1050
+
+def test_create_checkout_session_no_stripe(monkeypatch):
+    monkeypatch.setattr(stripe_service, 'stripe', None)
+    invoice = Invoice(1, 5, 1)
+    with pytest.raises(RuntimeError):
+        stripe_service.create_checkout_session(invoice, 'ok', 'ko')
+
+def test_verify_webhook(monkeypatch):
+    events = {}
+    def construct_event(payload, sig, secret):
+        events['payload'] = payload
+        events['sig'] = sig
+        events['secret'] = secret
+        return {'id': 'evt_1'}
+    fake_stripe = types.SimpleNamespace(Webhook=types.SimpleNamespace(construct_event=construct_event))
+    monkeypatch.setattr(stripe_service, 'stripe', fake_stripe)
+    monkeypatch.setenv('STRIPE_WEBHOOK_SECRET', 'whsec')
+    event = stripe_service.verify_webhook(b'data', 'sig')
+    assert event == {'id': 'evt_1'}
+    assert events['secret'] == 'whsec'
+
+def test_verify_webhook_no_stripe(monkeypatch):
+    monkeypatch.setattr(stripe_service, 'stripe', None)
+    with pytest.raises(RuntimeError):
+        stripe_service.verify_webhook(b'data', 'sig')

--- a/src/pages/CheckIn.test.tsx
+++ b/src/pages/CheckIn.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CheckIn from './CheckIn';
+
+jest.mock('../services/api', () => ({
+  attendanceService: {
+    checkInOffice: jest.fn(),
+    checkInMission: jest.fn().mockResolvedValue({})
+  }
+}));
+
+test('switch to mission tab displays input', () => {
+  render(<CheckIn />);
+  fireEvent.click(screen.getByText('Pointage Mission'));
+  expect(screen.getByLabelText("Numéro d'ordre de mission")).toBeInTheDocument();
+});
+
+test('mission checkin calls service', async () => {
+  const { attendanceService } = require('../services/api');
+  render(<CheckIn />);
+  fireEvent.click(screen.getByText('Pointage Mission'));
+  fireEvent.change(screen.getByLabelText("Numéro d'ordre de mission"), { target: { value: 'M1' } });
+  fireEvent.click(screen.getByText('Pointer en Mission'));
+  await waitFor(() => expect(attendanceService.checkInMission).toHaveBeenCalledWith('M1'));
+});


### PR DESCRIPTION
## Summary
- add unit tests for stripe service behaviors
- add basic admin routes test
- cover CheckIn page interactions with React tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a6c0e8a883328cf51b329175590f