### PR TITLE
Add checkout quick action

### DIFF
--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -19,6 +19,7 @@ import {
   CheckCircle,
   TrendingUp,
   DollarSign
+  LogOut
 } from 'lucide-react'
 import toast from 'react-hot-toast'
 
@@ -60,6 +61,33 @@ export default function QuickActions() {
     document.body.appendChild(link)
     link.click()
     link.remove()
+  }
+
+  const checkout = async () => {
+    await attendanceService.checkout()
+    toast.success("Heure de d\u00e9part enregistr\u00e9e")
+  }
+
+  const downloadCalendarAction: QuickAction = {
+    id: 'download-calendar',
+    title: 'Exporter calendrier',
+    description: 'iCal des pointages',
+    icon: Download,
+    color: 'text-indigo-600',
+    bgColor: 'bg-indigo-50',
+    hoverColor: 'hover:bg-indigo-100',
+    onClick: downloadCalendar
+  }
+
+  const checkoutAction: QuickAction = {
+    id: 'checkout',
+    title: 'Fin de journ\u00e9e',
+    description: 'Enregistrer votre d\u00e9part',
+    icon: LogOut,
+    color: 'text-red-600',
+    bgColor: 'bg-red-50',
+    hoverColor: 'hover:bg-red-100',
+    onClick: checkout
   }
 
   // Actions SuperAdmin
@@ -116,16 +144,8 @@ export default function QuickActions() {
       },
       badge: 'OK'
     },
-    {
-      id: 'download-calendar',
-      title: 'Exporter calendrier',
-      description: 'iCal des pointages',
-      icon: Download,
-      color: 'text-indigo-600',
-      bgColor: 'bg-indigo-50',
-      hoverColor: 'hover:bg-indigo-100',
-      onClick: downloadCalendar
-    }
+    downloadCalendarAction,
+    checkoutAction
   ]
 
   // Actions Admin
@@ -169,16 +189,8 @@ export default function QuickActions() {
         toast.info('Configuration du géofencing')
       }
     },
-    {
-      id: 'download-calendar',
-      title: 'Exporter calendrier',
-      description: 'iCal des pointages',
-      icon: Download,
-      color: 'text-indigo-600',
-      bgColor: 'bg-indigo-50',
-      hoverColor: 'hover:bg-indigo-100',
-      onClick: downloadCalendar
-    }
+    downloadCalendarAction,
+    checkoutAction
   ]
 
   // Actions Employé
@@ -222,16 +234,8 @@ export default function QuickActions() {
         toast.info('Affichage de votre historique')
       }
     },
-    {
-      id: 'download-calendar',
-      title: 'Exporter calendrier',
-      description: 'iCal des pointages',
-      icon: Download,
-      color: 'text-indigo-600',
-      bgColor: 'bg-indigo-50',
-      hoverColor: 'hover:bg-indigo-100',
-      onClick: downloadCalendar
-    }
+    downloadCalendarAction,
+    checkoutAction
   ]
 
   // Sélectionner les actions selon le rôle

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -159,6 +159,16 @@ export const attendanceService = {
       throw error
     }
   },
+
+  checkout: async () => {
+    try {
+      console.log("\uD83D\uDC4B Enregistrement de l'heure de d\u00e9part...")
+      return await api.post('/attendance/checkout')
+    } catch (error) {
+      console.error('Checkout service error:', error)
+      throw error
+    }
+  },
 }
 
 // Services SuperAdmin


### PR DESCRIPTION
## Summary
- avoid quick action duplication by sharing action objects
- add checkout API service and quick action

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ac900d348332911b44939c5c806a