### PR TITLE
Add company branding settings

### DIFF
--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -75,6 +75,8 @@ def init_database():
             email='contact@demo.pointflex.com',
             phone='+33123456789',
             address='123 Rue de la Démo, 75001 Paris',
+            logo_url=None,
+            theme_color='#3b82f6',
             subscription_plan='premium',
             is_active=True,
             office_latitude=48.8566,  # Paris

--- a/backend/models/company.py
+++ b/backend/models/company.py
@@ -35,6 +35,10 @@ class Company(db.Model):
     office_radius = db.Column(db.Integer, default=100)  # mètres
     work_start_time = db.Column(db.Time, default=datetime.strptime('09:00', '%H:%M').time())
     late_threshold = db.Column(db.Integer, default=15)  # minutes
+
+    # Personnalisation d'entreprise
+    logo_url = db.Column(db.String(255), nullable=True)
+    theme_color = db.Column(db.String(20), default='#3b82f6')  # bleu par défaut
     
     # Statut et métadonnées
     is_active = db.Column(db.Boolean, default=True, nullable=False)
@@ -136,6 +140,8 @@ class Company(db.Model):
             'industry': self.industry,
             'website': self.website,
             'tax_id': self.tax_id,
+            'logo_url': self.logo_url,
+            'theme_color': self.theme_color,
             'subscription_plan': self.subscription_plan,
             'subscription_status': self.subscription_status,
             'max_employees': self.max_employees,

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -112,6 +112,8 @@ class User(db.Model):
             'role': self.role,
             'company_id': self.company_id,
             'company_name': self.company.name if self.company else None,
+            'company_logo_url': self.company.logo_url if self.company else None,
+            'company_theme_color': self.company.theme_color if self.company else None,
             'employee_number': self.employee_number,
             'phone': self.phone,
             'is_active': self.is_active,

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -760,6 +760,20 @@ def delete_office(office_id):
         db.session.rollback()
         return jsonify(message="Erreur interne du serveur"), 500
 
+@admin_bp.route('/company/settings', methods=['GET'])
+@require_admin
+def get_company_settings():
+    """Récupère les paramètres de l'entreprise"""
+    current_user = get_current_user()
+
+    if not current_user.company_id:
+        return jsonify(message="Aucune entreprise associée à cet utilisateur"), 400
+
+    company = Company.query.get_or_404(current_user.company_id)
+
+    return jsonify({'company': company.to_dict(include_sensitive=True)}), 200
+
+
 @admin_bp.route('/company/settings', methods=['PUT'])
 @require_admin
 def update_company_settings():
@@ -780,7 +794,7 @@ def update_company_settings():
         # Mettre à jour les champs
         updatable_fields = [
             'office_latitude', 'office_longitude', 'office_radius',
-            'work_start_time', 'late_threshold'
+            'work_start_time', 'late_threshold', 'logo_url', 'theme_color'
         ]
         
         for field in updatable_fields:

--- a/src/components/CompanyManagement.tsx
+++ b/src/components/CompanyManagement.tsx
@@ -84,6 +84,8 @@ interface Company {
   is_active: boolean
   is_suspended: boolean
   suspension_reason?: string
+  logo_url?: string
+  theme_color?: string
   created_at: string
   updated_at: string
   admin_id?: number
@@ -115,6 +117,8 @@ interface CompanyForm {
   admin_nom: string
   admin_phone: string
   admin_password: string
+  logo_url?: string
+  theme_color?: string
 }
 
 export default function CompanyManagement() {

--- a/src/components/CompanySettings.tsx
+++ b/src/components/CompanySettings.tsx
@@ -11,7 +11,9 @@ export default function CompanySettings() {
     office_longitude: 2.3522,
     office_radius: 100,
     work_start_time: '09:00',
-    late_threshold: 15
+    late_threshold: 15,
+    logo_url: '',
+    theme_color: '#3b82f6'
   })
   const [saving, setSaving] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -27,18 +29,9 @@ export default function CompanySettings() {
   const loadCompanySettings = async () => {
     try {
       setDataLoading(true)
-      // Simuler le chargement des paramètres depuis l'API
-      // En production, remplacer par un appel API réel
-      setTimeout(() => {
-        setSettings({
-          office_latitude: 48.8566,
-          office_longitude: 2.3522,
-          office_radius: 100,
-          work_start_time: '09:00',
-          late_threshold: 15
-        })
-        setDataLoading(false)
-      }, 1000)
+      const resp = await adminService.getCompanySettings()
+      setSettings(resp.data.company)
+      setDataLoading(false)
     } catch (error) {
       console.error('Erreur lors du chargement des paramètres:', error)
       toast.error('Erreur lors du chargement des paramètres')
@@ -193,6 +186,38 @@ export default function CompanySettings() {
                   office_radius: parseInt(e.target.value)
                 }))}
                 className="input-field"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="flex items-center mb-4">
+            <MapPin className="h-5 w-5 text-purple-600 mr-2" />
+            <h3 className="text-lg font-semibold text-gray-900">Identité visuelle</h3>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Logo (URL)
+              </label>
+              <input
+                type="text"
+                value={settings.logo_url}
+                onChange={(e) => setSettings(prev => ({ ...prev, logo_url: e.target.value }))}
+                className="input-field"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Couleur principale
+              </label>
+              <input
+                type="color"
+                value={settings.theme_color}
+                onChange={(e) => setSettings(prev => ({ ...prev, theme_color: e.target.value }))}
+                className="input-field h-10 p-1"
               />
             </div>
           </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -39,6 +39,7 @@ export default function Layout({ children }: LayoutProps) {
   const location = useLocation()
   const navigate = useNavigate()
   const [sidebarOpen, setSidebarOpen] = React.useState(false)
+  const themeColor = user?.company_theme_color || '#2563eb'
 
   const handleLogout = () => {
     logout()
@@ -173,25 +174,32 @@ export default function Layout({ children }: LayoutProps) {
         <div className="fixed inset-y-0 left-0 flex w-64 flex-col bg-white shadow-xl">
           <div className="flex h-16 items-center justify-between px-4 border-b border-gray-200">
             <div className="flex items-center space-x-3">
-              {/* Logo PointFlex dans la sidebar */}
-              <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-blue-600 rounded-lg flex items-center justify-center">
-                <svg 
-                  width="16" 
-                  height="16" 
-                  viewBox="0 0 16 16" 
-                  fill="none" 
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="text-white"
+              {/* Logo dynamique */}
+              {user?.company_logo_url ? (
+                <img src={user.company_logo_url} alt="Logo" className="w-8 h-8 rounded-lg object-contain" />
+              ) : (
+                <div
+                  className="w-8 h-8 rounded-lg flex items-center justify-center"
+                  style={{ backgroundColor: themeColor }}
                 >
-                  <path 
-                    d="M3 8 L6.5 11.5 L13 5" 
-                    stroke="currentColor" 
-                    strokeWidth="1.5" 
-                    strokeLinecap="round" 
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </div>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="text-white"
+                  >
+                    <path
+                      d="M3 8 L6.5 11.5 L13 5"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </div>
+              )}
               <div>
                 <h1 className="text-lg font-bold">
                   <span className="text-blue-600">Point</span>
@@ -265,25 +273,32 @@ export default function Layout({ children }: LayoutProps) {
         <div className="flex flex-col flex-grow bg-white border-r border-gray-200 shadow-sm">
           <div className="flex h-16 items-center px-4 border-b border-gray-200">
             <div className="flex items-center space-x-3">
-              {/* Logo PointFlex */}
-              <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-blue-600 rounded-lg flex items-center justify-center">
-                <svg 
-                  width="16" 
-                  height="16" 
-                  viewBox="0 0 16 16" 
-                  fill="none" 
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="text-white"
+              {/* Logo dynamique */}
+              {user?.company_logo_url ? (
+                <img src={user.company_logo_url} alt="Logo" className="w-8 h-8 rounded-lg object-contain" />
+              ) : (
+                <div
+                  className="w-8 h-8 rounded-lg flex items-center justify-center"
+                  style={{ backgroundColor: themeColor }}
                 >
-                  <path 
-                    d="M3 8 L6.5 11.5 L13 5" 
-                    stroke="currentColor" 
-                    strokeWidth="1.5" 
-                    strokeLinecap="round" 
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </div>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="text-white"
+                  >
+                    <path
+                      d="M3 8 L6.5 11.5 L13 5"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </div>
+              )}
               <div>
                 <h1 className="text-lg font-bold">
                   <span className="text-blue-600">Point</span>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,6 +11,8 @@ interface User {
   role: UserRole
   company_id?: number | undefined
   company_name?: string | undefined
+  company_logo_url?: string | undefined
+  company_theme_color?: string | undefined
 }
 
 interface AuthContextType {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -573,6 +573,15 @@ export const adminService = {
       throw error
     }
   },
+
+  getCompanySettings: async () => {
+    try {
+      return await api.get('/admin/company/settings')
+    } catch (error) {
+      console.error('Get company settings service error:', error)
+      throw error
+    }
+  },
   
   // Service pour mettre à jour les paramètres de l'entreprise
   updateCompanySettings: async (settings: any) => {


### PR DESCRIPTION
## Summary
- add logo_url and theme_color fields to Company
- expose company settings via GET endpoint and allow updating branding
- include company branding in user info
- show company logo in layout
- allow admins to edit branding settings in UI
- update frontend API service for company settings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68666557e73483328ea3f76c6a1df00e