### PR TITLE
Fix SSE proxy path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
         target: 'http://localhost:5000',
         changeOrigin: true,
       },
+      '/stream': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+        ws: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy `/stream` to the backend

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6867bab8914c8332a3cbfd22696a812d