### PR TITLE
feat: Implement multiple backend enhancements and manager assignment UI

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -413,6 +413,15 @@ export const superAdminService = {
       console.error('Create customer portal session service error:', error)
       throw error
     }
+  },
+
+  setEmployeeManager: async (employeeId: number, managerId: number | null) => {
+    try {
+      return await api.put(`/admin/employees/${employeeId}/manager`, { manager_id: managerId });
+    } catch (error) {
+      console.error('Set employee manager service error:', error);
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
This commit delivers a significant batch of backend enhancements and the initial frontend UI for manager assignment.

Backend Enhancements:
1.  **Granular Manager Permissions:**
    *   User model updated with `manager_id` and `direct_reports`.
    *   API for admins to set employee managers (`PUT /api/admin/employees/<id>/manager`).
    *   Scoped Leave, Attendance PDF, and Calendar routes for managers to access data primarily for their direct reports.

2.  **Automated Annual Leave Accrual (Backend Logic):**
    *   `LeaveType` model updated with `annual_accrual_days`.
    *   Flask CLI command (`flask accrue-leave`) to process annual accruals with basic idempotency and audit logging.

3.  **Leave Policy Configuration (Backend Logic):**
    *   `Company` model updated for `work_days` and `default_country_code_for_holidays`.
    *   New `CompanyHoliday` model.
    *   `calculate_workdays` function now uses these company policies.
    *   Admin APIs for managing leave policy settings and company holidays.

4.  **Two-Factor Authentication (Backend Logic):**
    *   Added `pyotp`, `qrcode[pil]`, `cryptography`.
    *   User model updated for 2FA (secret, enabled status, backup codes).
    *   Encryption utilities for TOTP secrets.
    *   APIs for 2FA setup, verification/enablement, login step, disable, backup codes.
    *   Login flow modified to support 2FA challenge.

Frontend Enhancements:
1.  **Manager Assignment UI:**
    *   `EmployeeManagement.tsx` updated to allow admins to select a manager for an employee from a dropdown list.
    *   `manager_id` included in form data for employee creation/update.
    *   **Note:** Corresponding backend changes to `create_employee` and `update_employee` in `admin_routes.py` are required to process and save the `manager_id`.

Further frontend work is pending for 2FA setup, leave policy configuration, and full testing of all features.