### PR TITLE
feat: Implement half-day leave support, leave PDF reports, and calend…

### DIFF
--- a/backend/models/leave_request.py
+++ b/backend/models/leave_request.py
@@ -9,10 +9,21 @@ from backend.models.user import User # Added User import
 from backend.models.company import Company # To fetch company policy
 from backend.models.company_holiday import CompanyHoliday # To fetch company specific holidays
 
-# Updated function to calculate working days considering company policies
-def calculate_workdays(start_date: date, end_date: date, company_id: int) -> float:
+# Updated function to calculate working days considering company policies and partial days
+def calculate_workdays(
+    start_date: date,
+    end_date: date,
+    company_id: int,
+    start_day_period: str = "full_day",
+    end_day_period: str = "full_day"
+) -> float:
     if start_date > end_date:
         return 0.0
+
+    # Validate periods
+    valid_periods = ["full_day", "half_day_morning", "half_day_afternoon"]
+    if start_day_period not in valid_periods or end_day_period not in valid_periods:
+        raise ValueError("Invalid start_day_period or end_day_period value.")
 
     company = Company.query.get(company_id)
     if not company:
@@ -61,7 +72,28 @@ def calculate_workdays(start_date: date, end_date: date, company_id: int) -> flo
         if current_processing_date.weekday() in work_days_indices and \
            current_processing_date not in national_holidays and \
            current_processing_date not in company_specific_holidays:
-            workdays_count += 1.0
+
+            current_day_value = 1.0 # Assume a full workday
+
+            is_single_day_leave = (start_date == end_date)
+
+            if is_single_day_leave:
+                if start_day_period != "full_day" or end_day_period != "full_day":
+                    # If either start or end period specifies a half day for a single day leave, it's 0.5 days.
+                    # UI should ideally ensure start_day_period and end_day_period are consistent for single day
+                    # (e.g., both "half_day_morning" or one is "full_day" and other is "half_day_morning")
+                    # or guide that "half_day_morning" start and "half_day_afternoon" end on same day is 1 full day.
+                    # For simplicity here: any mention of half-day makes it 0.5 for a single day.
+                    # If start=morning, end=afternoon on same day, UI should make it a full_day request.
+                    current_day_value = 0.5
+            else: # Multi-day leave
+                if current_processing_date == start_date and start_day_period != "full_day":
+                    current_day_value = 0.5
+                elif current_processing_date == end_date and end_day_period != "full_day":
+                    current_day_value = 0.5
+                # Else, it's a full day (1.0) if it's a middle day of the leave period
+
+            workdays_count += current_day_value
         current_processing_date += timedelta(days=1)
 
     return workdays_count
@@ -77,10 +109,9 @@ class LeaveRequest(db.Model):
     start_date = db.Column(db.Date, nullable=False)
     end_date = db.Column(db.Date, nullable=False)
 
-    # For partial days, e.g., 'half_day_morning', 'half_day_afternoon', 'full_day'
-    # This adds complexity, for now assume full days.
-    # start_day_period = db.Column(db.String(20), default='full_day')
-    # end_day_period = db.Column(db.String(20), default='full_day')
+    # For partial days
+    start_day_period = db.Column(db.String(20), default='full_day', nullable=False) # "full_day", "half_day_morning", "half_day_afternoon"
+    end_day_period = db.Column(db.String(20), default='full_day', nullable=False)   # "full_day", "half_day_morning", "half_day_afternoon"
 
     reason = db.Column(db.Text, nullable=True)
     status = db.Column(db.String(20), default='pending', nullable=False, index=True) # pending, approved, rejected, cancelled
@@ -101,40 +132,32 @@ class LeaveRequest(db.Model):
 
 
     def __init__(self, **kwargs):
+        # Pop custom args before passing to super
+        start_day_period_arg = kwargs.pop('start_day_period', 'full_day')
+        end_day_period_arg = kwargs.pop('end_day_period', 'full_day')
+
         super(LeaveRequest, self).__init__(**kwargs)
+
+        # Ensure these are set from kwargs or defaults if not already on self (e.g. if object is loaded from DB)
+        if not hasattr(self, 'start_day_period') or self.start_day_period is None:
+            self.start_day_period = start_day_period_arg
+        if not hasattr(self, 'end_day_period') or self.end_day_period is None:
+            self.end_day_period = end_day_period_arg
+
         if self.start_date and self.end_date and self.user_id:
-            # Fetch the user to get their company_id for accurate workday calculation
-            # This adds a DB query during __init__, which is generally okay for new objects.
-            # If user object is already available (e.g. passed to constructor), that's better.
-            user_for_calc = db.session.get(User, self.user_id) # Use db.session.get for SQLAlchemy 2.0+ style if User is imported
-            if not user_for_calc : # Fallback if user somehow not found yet
-                # This should not happen if user_id is a valid FK.
-                # We might need to handle this or ensure user_id is always set before __init__ logic.
-                # For now, if no user, can't get company_id, so might default or raise.
-                # Defaulting to 0 days or raising an error might be safer.
-                # Let's assume user_id is valid and user will be found.
-                pass # Should not happen with proper FKs
+            user_for_calc = db.session.get(User, self.user_id)
+            if not user_for_calc:
+                 raise ValueError(f"User with ID {self.user_id} not found for LeaveRequest initialization.")
+            if not user_for_calc.company_id:
+                raise ValueError(f"User {self.user_id} must belong to a company to request leave.")
 
-            if user_for_calc and user_for_calc.company_id:
-                self.requested_days = calculate_workdays(self.start_date, self.end_date, user_for_calc.company_id)
-            else:
-                # If user has no company, or for some reason company_id is not set,
-                # workday calculation might default or be inaccurate.
-                # Consider a global default or raise an error.
-                # For now, if no company_id, it might use a default policy in calculate_workdays.
-                # This path should be rare for leave requests tied to employment.
-                # Let's ensure calculate_workdays handles a None company_id gracefully or we prevent this.
-                # The current calculate_workdays expects a company_id.
-                # So, if user_for_calc.company_id is None, this will fail.
-                # We must ensure company_id is available.
-                # A user requesting leave should always have a company.
-                if not user_for_calc: # Should not occur with Flask-SQLAlchemy session context
-                     raise ValueError("User not found for calculating workdays in LeaveRequest init.")
-                if not user_for_calc.company_id:
-                    raise ValueError(f"User {user_for_calc.id} requesting leave must belong to a company for workday calculation.")
-                # This line will now only be reached if company_id is present.
-                self.requested_days = calculate_workdays(self.start_date, self.end_date, user_for_calc.company_id)
-
+            self.requested_days = calculate_workdays(
+                self.start_date,
+                self.end_date,
+                user_for_calc.company_id,
+                self.start_day_period, # Use the instance's period
+                self.end_day_period   # Use the instance's period
+            )
 
     def to_dict(self):
         return {
@@ -145,6 +168,8 @@ class LeaveRequest(db.Model):
             'leave_type_name': self.leave_type.name if self.leave_type else None,
             'start_date': self.start_date.isoformat(),
             'end_date': self.end_date.isoformat(),
+            'start_day_period': self.start_day_period,
+            'end_day_period': self.end_day_period,
             'reason': self.reason,
             'status': self.status,
             'requested_days': self.requested_days,

--- a/backend/routes/profile_routes.py
+++ b/backend/routes/profile_routes.py
@@ -265,3 +265,101 @@ def export_profile_data():
     except Exception as e:
         print(f"Erreur lors de l'export du profil: {e}")
         return jsonify(message="Erreur interne du serveur"), 500
+
+from backend.models.leave_request import LeaveRequest # Already imported for /my-leave-requests practically
+from backend.utils.pdf_utils import build_pdf_document, create_styled_table, get_report_styles, generate_report_title_elements
+from reportlab.platypus import Paragraph, Spacer # Already imported
+from reportlab.lib.units import inch # Already imported
+from io import BytesIO # Already imported
+from flask import send_file, current_app # Already imported for other pdfs, ensure here
+# from datetime import datetime # Already imported
+
+@profile_bp.route('/my-leave-report/pdf', methods=['GET'])
+@jwt_required()
+def my_leave_history_pdf():
+    """Génère un rapport PDF de l'historique des congés de l'utilisateur connecté."""
+    try:
+        current_user = get_current_user()
+        if not current_user:
+            return jsonify(message="Utilisateur non trouvé"), 401
+
+        start_date_str = request.args.get('start_date')
+        end_date_str = request.args.get('end_date')
+        status_filter = request.args.get('status')
+
+        query = LeaveRequest.query.filter_by(user_id=current_user.id)
+
+        report_filters_texts = []
+        if start_date_str:
+            start_date = datetime.strptime(start_date_str, '%Y-%m-%d').date()
+            query = query.filter(LeaveRequest.start_date >= start_date)
+            report_filters_texts.append(f"Début: {start_date.strftime('%d/%m/%Y')}")
+        if end_date_str:
+            end_date = datetime.strptime(end_date_str, '%Y-%m-%d').date()
+            query = query.filter(LeaveRequest.end_date <= end_date)
+            report_filters_texts.append(f"Fin: {end_date.strftime('%d/%m/%Y')}")
+        if status_filter:
+            query = query.filter(LeaveRequest.status == status_filter)
+            report_filters_texts.append(f"Statut: {status_filter}")
+
+        period_str = ", ".join(report_filters_texts) if report_filters_texts else "toutes périodes"
+
+        leave_requests = query.order_by(LeaveRequest.start_date.desc()).all()
+
+        buffer = BytesIO()
+        styles = get_report_styles()
+
+        story = generate_report_title_elements(
+            title_str=f"Mon Historique de Congés - {current_user.prenom} {current_user.nom}",
+            period_str=period_str
+        )
+
+        if not leave_requests:
+            story.append(Paragraph("Aucune demande de congé trouvée pour les filtres sélectionnés.", styles['Normal']))
+        else:
+            table_data = [
+                [Paragraph(col, styles['SmallText']) for col in
+                    ["Type Congé", "Début", "Fin", "P.Début", "P.Fin", "Jours Dem.", "Statut", "Motif", "Approuvé par", "Comm. Approb."]]
+            ]
+
+            for lr in leave_requests:
+                approver_name = f"{lr.approved_by.prenom} {lr.approved_by.nom}" if lr.approved_by else "N/A"
+                table_data.append([
+                    Paragraph(lr.leave_type.name if lr.leave_type else "N/A", styles['SmallText']),
+                    lr.start_date.strftime('%d/%m/%y'),
+                    lr.end_date.strftime('%d/%m/%y'),
+                    Paragraph(lr.start_day_period.replace('_', ' ').replace('half day ', '½j '), styles['SmallText']),
+                    Paragraph(lr.end_day_period.replace('_', ' ').replace('half day ', '½j '), styles['SmallText']),
+                    str(lr.requested_days),
+                    Paragraph(lr.status, styles['SmallText']),
+                    Paragraph(lr.reason or "", styles['SmallText']),
+                    Paragraph(approver_name, styles['SmallText']),
+                    Paragraph(lr.approver_comments or "", styles['SmallText'])
+                ])
+
+            col_widths = [1*inch, 0.6*inch, 0.6*inch, 0.7*inch, 0.7*inch, 0.5*inch, 0.7*inch, 1.2*inch, 1*inch, 1.3*inch]
+
+            custom_table_styles = [
+                ('FONTSIZE', (0,0), (-1,-1), 7),
+                ('VALIGN', (0,0), (-1,-1), 'TOP'),
+                ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.white, colors.HexColor('#FAFAFA')]),
+                ('ALIGN', (1,1), (6, -1), 'CENTER'), # Dates, Periods, Days, Status
+                ('ALIGN', (0,1), (0, -1), 'LEFT'),   # Type
+                ('ALIGN', (7,1), (-1, -1), 'LEFT'),  # Reason, Approver, Comments
+            ]
+            leave_table = create_styled_table(table_data, col_widths=col_widths, style_commands=custom_table_styles)
+            story.append(leave_table)
+
+        final_pdf_buffer = build_pdf_document(
+            buffer, story,
+            title=f"Historique Congés - {current_user.prenom} {current_user.nom}",
+            author="PointFlex Application"
+        )
+
+        return send_file(final_pdf_buffer, mimetype='application/pdf',
+                         as_attachment=True,
+                         download_name=f'mon_historique_conges_{current_user.nom.lower()}_{datetime.now().strftime("%Y%m%d")}.pdf')
+
+    except Exception as e:
+        current_app.logger.error(f"Erreur génération PDF historique congés pour utilisateur {current_user.id if 'current_user' in locals() and current_user else 'N/A'}: {e}", exc_info=True)
+        return jsonify(message="Erreur interne du serveur lors de la génération du PDF."), 500

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,8 +24,9 @@ import OrganizationManagement from './pages/OrganizationManagement'
 import AdvancedFeatures from './pages/AdvancedFeatures'
 import RoleManagementPage from './pages/RoleManagementPage'
 import BillingManagement from './pages/BillingManagement'
-import WebhookManagementPage from './pages/WebhookManagementPage' // Added Webhook Page
+import WebhookManagementPage from './pages/WebhookManagementPage'
 import Missions from './pages/Missions'
+import RequestLeavePage from './pages/RequestLeavePage'; // Added RequestLeavePage
 import Layout from './components/Layout'
 
 function ProtectedRoute({ children, requiredRole }: { children: React.ReactNode, requiredRole?: string }) {
@@ -241,6 +242,13 @@ function App() {
             <ProtectedRoute>
               <Layout>
                 <Profile />
+              </Layout>
+            </ProtectedRoute>
+          } />
+          <Route path="/request-leave" element={
+            <ProtectedRoute>
+              <Layout>
+                <RequestLeavePage />
               </Layout>
             </ProtectedRoute>
           } />

--- a/src/components/LeaveRequestForm.tsx
+++ b/src/components/LeaveRequestForm.tsx
@@ -1,0 +1,322 @@
+import React, { useState, useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { leaveService } from '../services/api';
+import toast from 'react-hot-toast';
+import { CalendarDays, Send, Info } from 'lucide-react';
+import LoadingSpinner from './shared/LoadingSpinner';
+
+interface LeaveType {
+  id: number;
+  name: string;
+  is_paid: boolean;
+}
+
+interface LeaveBalance {
+  leave_type_id: number;
+  leave_type_name: string;
+  balance_days: number;
+}
+
+interface LeaveRequestFormData {
+  leave_type_id: string; // Will be string from select, convert to number
+  start_date: string;
+  end_date: string;
+  start_day_period: 'full_day' | 'half_day_morning' | 'half_day_afternoon';
+  end_day_period: 'full_day' | 'half_day_morning' | 'half_day_afternoon';
+  reason: string;
+}
+
+const defaultValues: LeaveRequestFormData = {
+  leave_type_id: '',
+  start_date: '',
+  end_date: '',
+  start_day_period: 'full_day',
+  end_day_period: 'full_day',
+  reason: '',
+};
+
+interface LeaveRequestFormProps {
+  onSuccess?: () => void; // Callback on successful submission
+}
+
+export default function LeaveRequestForm({ onSuccess }: LeaveRequestFormProps) {
+  const [leaveTypes, setLeaveTypes] = useState<LeaveType[]>([]);
+  const [leaveBalances, setLeaveBalances] = useState<LeaveBalance[]>([]);
+  const [isLoadingTypes, setIsLoadingTypes] = useState(true);
+  const [isLoadingBalances, setIsLoadingBalances] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [calculatedDuration, setCalculatedDuration] = useState<number | null>(null);
+  const [isCalculatingDuration, setIsCalculatingDuration] = useState(false);
+
+  const { control, handleSubmit, watch, formState: { errors }, reset } = useForm<LeaveRequestFormData>({ defaultValues });
+
+  const selectedLeaveTypeId = watch('leave_type_id');
+  const startDate = watch('start_date');
+  const endDate = watch('end_date');
+  const startDayPeriod = watch('start_day_period');
+  const endDayPeriod = watch('end_day_period');
+
+  // Debounce function
+  const debounce = <F extends (...args: any[]) => any>(func: F, waitFor: number) => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    return (...args: Parameters<F>): Promise<ReturnType<F>> =>
+      new Promise(resolve => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        timeoutId = setTimeout(() => resolve(func(...args)), waitFor);
+      });
+  };
+
+  const debouncedCalculateDuration = debounce(leaveService.calculateLeaveDuration, 500);
+
+  useEffect(() => {
+    if (startDate && endDate && new Date(endDate) >= new Date(startDate)) {
+      setIsCalculatingDuration(true);
+      debouncedCalculateDuration({
+        start_date: startDate,
+        end_date: endDate,
+        start_day_period: startDayPeriod,
+        end_day_period: endDayPeriod,
+      })
+      .then(response => {
+        setCalculatedDuration(response.data.calculated_days);
+      })
+      .catch(error => {
+        console.error("Error calculating duration:", error);
+        setCalculatedDuration(null); // Clear on error
+        // Optionally show a small error to user if calculation fails
+      })
+      .finally(() => {
+        setIsCalculatingDuration(false);
+      });
+    } else {
+      setCalculatedDuration(null); // Clear if dates are invalid
+    }
+  }, [startDate, endDate, startDayPeriod, endDayPeriod, debouncedCalculateDuration]); // Added debouncedCalculateDuration to dep array
+
+  // Effect to manage interdependent period fields
+  const { setValue } = useForm<LeaveRequestFormData>({ defaultValues }); // Get setValue from useForm
+
+  useEffect(() => {
+    const isSingleDay = startDate && endDate && startDate === endDate;
+
+    if (isSingleDay) {
+      if (startDayPeriod === 'half_day_morning') {
+        setValue('end_day_period', 'half_day_morning', { shouldValidate: true, shouldDirty: true });
+      } else if (startDayPeriod === 'half_day_afternoon') {
+        setValue('end_day_period', 'half_day_afternoon', { shouldValidate: true, shouldDirty: true });
+      } else { // full_day
+        setValue('end_day_period', 'full_day', { shouldValidate: true, shouldDirty: true });
+      }
+    }
+    // No specific restrictions for end_day_period if multi-day, as backend calculation handles it.
+    // UI could further restrict options in dropdown if desired (e.g. end_day_period cannot be 'half_day_afternoon' if not single day)
+  }, [startDate, endDate, startDayPeriod, setValue]);
+
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoadingTypes(true);
+        const typesResponse = await leaveService.getLeaveTypes();
+        setLeaveTypes(typesResponse.data || []);
+      } catch (error) {
+        toast.error("Erreur de chargement des types de congé.");
+      } finally {
+        setIsLoadingTypes(false);
+      }
+
+      try {
+        setIsLoadingBalances(true);
+        const balancesResponse = await leaveService.getLeaveBalances();
+        setLeaveBalances(balancesResponse.data || []);
+      } catch (error) {
+        toast.error("Erreur de chargement des soldes de congé.");
+      } finally {
+        setIsLoadingBalances(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const currentBalanceForSelectedType = (): number | null => {
+    if (!selectedLeaveTypeId) return null;
+    const balance = leaveBalances.find(b => b.leave_type_id === parseInt(selectedLeaveTypeId, 10));
+    return balance ? balance.balance_days : null;
+  };
+
+  const selectedLeaveTypeIsPaid = (): boolean => {
+    if (!selectedLeaveTypeId) return false;
+    const type = leaveTypes.find(t => t.id === parseInt(selectedLeaveTypeId, 10));
+    return type ? type.is_paid : false;
+  }
+
+  const onSubmit = async (data: LeaveRequestFormData) => {
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        ...data,
+        leave_type_id: parseInt(data.leave_type_id, 10),
+      };
+      await leaveService.submitLeaveRequest(payload);
+      toast.success("Demande de congé soumise avec succès !");
+      reset(defaultValues); // Reset form
+      if (onSuccess) onSuccess();
+      // Refresh balances after submission (optional, or handled by parent)
+      try {
+        const balancesResponse = await leaveService.getLeaveBalances();
+        setLeaveBalances(balancesResponse.data || []);
+      } catch (e) { /* ignore */ }
+
+    } catch (error: any) {
+      // Toast error usually handled by API interceptor
+      console.error("Leave request submission error", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Basic validation for date range
+  const validateEndDate = (value: string) => {
+    if (startDate && value && new Date(value) < new Date(startDate)) {
+      return "La date de fin ne peut pas être antérieure à la date de début.";
+    }
+    return true;
+  };
+
+  return (
+    <div className="card max-w-2xl mx-auto">
+      <h2 className="text-xl font-semibold text-gray-800 mb-6 flex items-center">
+        <CalendarDays className="h-6 w-6 mr-2 text-primary-600" />
+        Nouvelle Demande de Congé
+      </h2>
+      {(isLoadingTypes || isLoadingBalances) && <LoadingSpinner text="Chargement des données..." />}
+
+      {!isLoadingTypes && !isLoadingBalances && (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 md:space-y-6">
+          <div>
+            <label htmlFor="leave_type_id" className="block text-sm font-medium text-gray-700 mb-1">Type de congé *</label>
+            <Controller
+              name="leave_type_id"
+              control={control}
+              rules={{ required: "Veuillez sélectionner un type de congé." }}
+              render={({ field }) => (
+                <select {...field} id="leave_type_id" className="input-field">
+                  <option value="">-- Sélectionner --</option>
+                  {leaveTypes.map(lt => (
+                    <option key={lt.id} value={lt.id}>{lt.name}</option>
+                  ))}
+                </select>
+              )}
+            />
+            {errors.leave_type_id && <p className="form-error-text">{errors.leave_type_id.message}</p>}
+            {selectedLeaveTypeId && selectedLeaveTypeIsPaid() && (
+              <p className="text-xs text-gray-600 mt-1">
+                Solde actuel pour ce type : <span className="font-medium">{currentBalanceForSelectedType() ?? 'N/A'}</span> jours.
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="start_date" className="block text-sm font-medium text-gray-700 mb-1">Date de début *</label>
+              <Controller
+                name="start_date"
+                control={control}
+                rules={{ required: "Date de début requise." }}
+                render={({ field }) => <input type="date" {...field} id="start_date" className="input-field" />}
+              />
+              {errors.start_date && <p className="form-error-text">{errors.start_date.message}</p>}
+            </div>
+            <div>
+              <label htmlFor="start_day_period" className="block text-sm font-medium text-gray-700 mb-1">Début de journée</label>
+              <Controller
+                name="start_day_period"
+                control={control}
+                render={({ field }) => (
+                  <select {...field} id="start_day_period" className="input-field">
+                    <option value="full_day">Journée entière</option>
+                    <option value="half_day_morning">Matin (0.5 jour)</option>
+                    <option value="half_day_afternoon">Après-midi (0.5 jour)</option>
+                  </select>
+                )}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="end_date" className="block text-sm font-medium text-gray-700 mb-1">Date de fin *</label>
+              <Controller
+                name="end_date"
+                control={control}
+                rules={{
+                  required: "Date de fin requise.",
+                  validate: validateEndDate
+                }}
+                render={({ field }) => <input type="date" {...field} id="end_date" className="input-field" />}
+              />
+              {errors.end_date && <p className="form-error-text">{errors.end_date.message}</p>}
+            </div>
+            <div>
+              <label htmlFor="end_day_period" className="block text-sm font-medium text-gray-700 mb-1">Fin de journée</label>
+              <Controller
+                name="end_day_period"
+                control={control}
+                render={({ field }) => (
+                  <select {...field} id="end_day_period" className="input-field">
+                    <option value="full_day">Journée entière</option>
+                    <option value="half_day_morning">Matin (0.5 jour)</option> {/* Useful if ending mid-day */}
+                    <option value="half_day_afternoon">Après-midi (0.5 jour)</option>
+                  </select>
+                )}
+              />
+            </div>
+          </div>
+
+          {startDate && endDate && startDate === endDate && watch("start_day_period") !== "full_day" && watch("end_day_period") !== "full_day" && watch("start_day_period") !== watch("end_day_period") && (
+             <div className="p-2 bg-yellow-50 border border-yellow-200 rounded-md text-xs text-yellow-700 flex items-center">
+                <Info size={14} className="mr-1.5 flex-shrink-0" />
+                Pour un seul jour, sélectionner la même période pour le début et la fin (ex: Matin & Matin) pour un demi-jour, ou "Journée entière" pour les deux.
+             </div>
+          )}
+
+
+          <div>
+            <label htmlFor="reason" className="block text-sm font-medium text-gray-700 mb-1">Motif (optionnel)</label>
+            <Controller
+              name="reason"
+              control={control}
+              render={({ field }) => <textarea {...field} id="reason" rows={3} className="input-field" placeholder="Ex: Vacances annuelles, Rendez-vous personnel..."></textarea>}
+            />
+          </div>
+
+
+          <div className="p-3 bg-blue-50 border border-blue-200 rounded-md">
+            <p className="text-sm font-medium text-blue-700">
+              Durée calculée de la demande :
+              <span className="ml-1 font-semibold">
+                {isCalculatingDuration ? (
+                    <span className="italic text-xs">Calcul...</span>
+                ) : calculatedDuration !== null ? (
+                    `${calculatedDuration} jour(s)`
+                ) : (
+                    'N/A'
+                )}
+              </span>
+            </p>
+            <p className="text-xs text-blue-600 mt-1">Ceci est une estimation basée sur les jours ouvrés et fériés de votre entreprise. Le décompte final sera confirmé lors de l'approbation.</p>
+          </div>
+
+          <div className="pt-2 text-right">
+            <button type="submit" className="btn-primary flex items-center" disabled={isSubmitting || isCalculatingDuration}>
+              {isSubmitting ? <LoadingSpinner size="sm" /> : <Send className="h-4 w-4 mr-2" />}
+              Soumettre la Demande
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/pages/RequestLeavePage.tsx
+++ b/src/pages/RequestLeavePage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import LeaveRequestForm from '../components/LeaveRequestForm';
+import { useNavigate } from 'react-router-dom';
+
+export default function RequestLeavePage() {
+  const navigate = useNavigate();
+
+  const handleSuccess = () => {
+    // Optionally navigate away or show a persistent success message on this page
+    // For now, let's assume the toast in the form is enough and user might want to make another request
+    // or navigate via sidebar.
+    // Example: navigate('/leave-history');
+  };
+
+  return (
+    <div className="container mx-auto p-4 md:p-6">
+      {/* Can add a page header here if needed */}
+      <LeaveRequestForm onSuccess={handleSuccess} />
+    </div>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -437,6 +437,19 @@ export const calendarService = {
       console.error('Get calendar events service error:', error);
       throw error;
     }
+  },
+  calculateLeaveDuration: async (data: {
+    start_date: string;
+    end_date: string;
+    start_day_period?: string;
+    end_day_period?: string;
+  }) => {
+    try {
+      return await api.post('/leave/calculate-duration', data);
+    } catch (error) {
+      console.error('Calculate leave duration error:', error);
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
…ar updates

This commit introduces support for half-day leave requests, new PDF reports for leave history, and enhances the team calendar to display this information.

Key changes:

1.  **Half-Day Leave Support (Backend & Frontend Form):**
    *   `LeaveRequest` model updated with `start_day_period` and `end_day_period` fields.
    *   `calculate_workdays` function enhanced to accurately calculate duration for full and half-day leave requests, considering company work policies and holidays.
    *   `POST /api/leave/requests` endpoint updated to accept period fields.
    *   New `POST /api/leave/calculate-duration` endpoint for frontend to dynamically get calculated leave duration.
    *   Frontend `LeaveRequestForm.tsx` created, allowing users to specify half-day periods and see the calculated duration before submission.
    *   Refined period dropdown logic in the form for better UX with single-day leaves.

2.  **Leave History PDF Reports (Backend):**
    *   New endpoint `GET /api/profile/my-leave-report/pdf` for users to download their own leave history.
    *   New endpoint `GET /api/admin/employees/<id>/leave-report/pdf` for admins/managers to download leave history for specific employees (with permission scoping).
    *   Reports include details of leave type, dates, periods (showing half-days), requested days, status, and approver information.

3.  **Calendar Display of Leave & Half-Days (Frontend & Backend):**
    *   Backend `GET /api/calendar/events` now includes approved leave requests in its data feed.
    *   Frontend `TeamCalendar.tsx` updated:
        *   `CalendarEvent` interface enhanced for leave period details.
        *   Displays leave events from the API.
        *   Shows clearer information for half-day leaves in event titles in the grid and in the day details panel.

Frontend UI for triggering PDF downloads and further calendar visual refinements for half-days are pending.