### PR TITLE
Fix duplicate model imports

### DIFF
--- a/backend/cli_commands.py
+++ b/backend/cli_commands.py
@@ -3,10 +3,10 @@ from flask.cli import with_appcontext
 from datetime import datetime, date
 
 from database import db
-from models.user import User
-from models.leave_type import LeaveType
-from models.leave_balance import LeaveBalance
-from models.audit_log import AuditLog # For logging the accrual action
+from backend.models.user import User
+from backend.models.leave_type import LeaveType
+from backend.models.leave_balance import LeaveBalance
+from backend.models.audit_log import AuditLog # For logging the accrual action
 
 def register_cli_commands(app):
     @app.cli.command('accrue-leave')

--- a/backend/database.py
+++ b/backend/database.py
@@ -11,24 +11,24 @@ db = SQLAlchemy()
 def init_db():
     """Initialise la base de données avec les données de test"""
     try:
-        from models.user import User
-        from models.company import Company
-        from models.pointage import Pointage
-        from models.system_settings import SystemSettings
-        from models.audit_log import AuditLog
-        from models.office import Office
-        from models.mission import Mission
-        from models.invoice import Invoice
-        from models.payment import Payment
-        from models.notification import Notification
-        from models.push_subscription import PushSubscription
-        from models.leave_type import LeaveType
-        from models.leave_balance import LeaveBalance
-        from models.leave_request import LeaveRequest
-        from models.webhook_subscription import WebhookSubscription
-        from models.webhook_delivery_log import WebhookDeliveryLog
-        from models.company_holiday import CompanyHoliday
-        from models.password_history import PasswordHistory # Added PasswordHistory
+        from backend.models.user import User
+        from backend.models.company import Company
+        from backend.models.pointage import Pointage
+        from backend.models.system_settings import SystemSettings
+        from backend.models.audit_log import AuditLog
+        from backend.models.office import Office
+        from backend.models.mission import Mission
+        from backend.models.invoice import Invoice
+        from backend.models.payment import Payment
+        from backend.models.notification import Notification
+        from backend.models.push_subscription import PushSubscription
+        from backend.models.leave_type import LeaveType
+        from backend.models.leave_balance import LeaveBalance
+        from backend.models.leave_request import LeaveRequest
+        from backend.models.webhook_subscription import WebhookSubscription
+        from backend.models.webhook_delivery_log import WebhookDeliveryLog
+        from backend.models.company_holiday import CompanyHoliday
+        from backend.models.password_history import PasswordHistory # Added PasswordHistory
         
         # Créer toutes les tables
         db.create_all()

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -13,9 +13,9 @@ from werkzeug.security import generate_password_hash
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from app import app, db
-from models.user import User
-from models.company import Company
-from models.system_settings import SystemSettings
+from backend.models.user import User
+from backend.models.company import Company
+from backend.models.system_settings import SystemSettings
 
 def init_database():
     """Initialise la base de données avec les données de base"""

--- a/backend/middleware/audit.py
+++ b/backend/middleware/audit.py
@@ -3,7 +3,7 @@ Middleware d'audit automatique
 """
 
 from flask import request, g
-from models.audit_log import AuditLog
+from backend.models.audit_log import AuditLog
 from database import db
 from datetime import datetime
 

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -5,8 +5,8 @@ Middleware d'authentification et autorisation
 from flask import request, jsonify, g
 from flask_jwt_extended import verify_jwt_in_request, get_jwt_identity, get_jwt
 from functools import wraps
-from models.user import User
-from models.audit_log import AuditLog
+from backend.models.user import User
+from backend.models.audit_log import AuditLog
 from database import db
 
 def init_auth_middleware(app, jwt):

--- a/backend/middleware/error_handler.py
+++ b/backend/middleware/error_handler.py
@@ -5,7 +5,7 @@ Gestionnaire d'erreurs centralisé
 from flask import jsonify, request
 from werkzeug.exceptions import HTTPException
 from sqlalchemy.exc import SQLAlchemyError
-from models.audit_log import AuditLog
+from backend.models.audit_log import AuditLog
 from database import db
 import traceback
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -44,5 +44,9 @@ __all__ = [
     'PushSubscription',
     'LeaveType',
     'LeaveBalance',
-    'LeaveRequest'
+    'LeaveRequest',
+    'WebhookSubscription',
+    'WebhookDeliveryLog',
+    'CompanyHoliday',
+    'PasswordHistory'
 ]

--- a/backend/models/pointage.py
+++ b/backend/models/pointage.py
@@ -56,7 +56,7 @@ class Pointage(db.Model):
     
     def calculate_status(self):
         """Calcule le statut du pointage (présent/retard)"""
-        from models.user import User
+        from backend.models.user import User
         
         user = User.query.get(self.user_id)
         if not user or not user.company:

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -6,13 +6,13 @@ from flask import Blueprint, request, jsonify, send_file
 from flask_jwt_extended import jwt_required
 from middleware.auth import require_admin, require_manager_or_above, get_current_user
 from middleware.audit import log_user_action
-from models.user import User
-from models.company import Company
-from models.office import Office
-from models.department import Department
-from models.service import Service
-from models.position import Position
-from models.pointage import Pointage
+from backend.models.user import User
+from backend.models.company import Company
+from backend.models.office import Office
+from backend.models.department import Department
+from backend.models.service import Service
+from backend.models.position import Position
+from backend.models.pointage import Pointage
 from io import BytesIO
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4

--- a/backend/routes/attendance_routes.py
+++ b/backend/routes/attendance_routes.py
@@ -7,10 +7,10 @@ from flask_jwt_extended import jwt_required
 from middleware.auth import get_current_user
 from middleware.audit import log_user_action
 from utils.notification_utils import send_notification
-from models.pointage import Pointage
-from models.user import User
-from models.mission import Mission
-from models.office import Office
+from backend.models.pointage import Pointage
+from backend.models.user import User
+from backend.models.mission import Mission
+from backend.models.office import Office
 from database import db
 from datetime import datetime, date, timedelta
 import math

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -4,8 +4,8 @@ Routes d'authentification
 
 from flask import Blueprint, request, jsonify, current_app
 from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
-from models.user import User
-from models.audit_log import AuditLog
+from backend.models.user import User
+from backend.models.audit_log import AuditLog
 from middleware.auth import get_current_user
 from middleware.audit import log_user_action
 from database import db

--- a/backend/routes/health_routes.py
+++ b/backend/routes/health_routes.py
@@ -5,9 +5,9 @@ Routes de santé et monitoring
 from flask import Blueprint, jsonify
 from datetime import datetime
 from database import db
-from models.user import User
-from models.company import Company
-from models.pointage import Pointage
+from backend.models.user import User
+from backend.models.company import Company
+from backend.models.pointage import Pointage
 from sqlalchemy import text
 
 health_bp = Blueprint('health', __name__)

--- a/backend/routes/mission_routes.py
+++ b/backend/routes/mission_routes.py
@@ -3,9 +3,9 @@
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
 from middleware.auth import get_current_user, require_admin
-from models.mission import Mission
-from models.mission_user import MissionUser
-from models.user import User
+from backend.models.mission import Mission
+from backend.models.mission_user import MissionUser
+from backend.models.user import User
 from database import db
 from backend.middleware.audit import log_user_action # Added for audit logging
 from flask import current_app # For logging

--- a/backend/routes/profile_routes.py
+++ b/backend/routes/profile_routes.py
@@ -251,7 +251,7 @@ def export_profile_data():
         if not current_user:
             return jsonify(message="Utilisateur non trouvé"), 401
 
-        from models.pointage import Pointage
+        from backend.models.pointage import Pointage
 
         pointages = Pointage.query.filter_by(user_id=current_user.id).order_by(
             Pointage.date_pointage

--- a/backend/routes/superadmin_routes.py
+++ b/backend/routes/superadmin_routes.py
@@ -6,13 +6,13 @@ from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required
 from middleware.auth import require_superadmin, get_current_user
 from middleware.audit import log_user_action
-from models.company import Company
-from models.user import User
-from models.pointage import Pointage
-from models.system_settings import SystemSettings
-from models.audit_log import AuditLog
-from models.invoice import Invoice
-from models.payment import Payment
+from backend.models.company import Company
+from backend.models.user import User
+from backend.models.pointage import Pointage
+from backend.models.system_settings import SystemSettings
+from backend.models.audit_log import AuditLog
+from backend.models.invoice import Invoice
+from backend.models.payment import Payment
 from services.stripe_service import create_checkout_session, verify_webhook
 from database import db
 from datetime import datetime, timedelta


### PR DESCRIPTION
## Summary
- consistently import models using `backend.models` to avoid duplicate metadata

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686c375d998883328acdc3c48ae8a5f7