### PR TITLE
Fix login comments and export server status check

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -29,6 +29,7 @@ interface AuthContextType {
   isAuditeur: boolean
   isAdmin: boolean // Garde la compatibilité - inclut admin_rh
   serverStatus: 'checking' | 'online' | 'offline'
+  checkServerStatus: () => Promise<boolean>
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -173,7 +174,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     isEmployee,
     isAuditeur,
     isAdmin,
-    serverStatus
+    serverStatus,
+    checkServerStatus: checkServerHealth
   }
 
   return (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -212,7 +212,6 @@ export default function Login() {
           )}
 
           {is2FARequired ? (
-            // --- 2FA OTP Form ---
             <form className="space-y-6" onSubmit={handle2FASubmit}>
               <div className="text-center">
                 <ShieldCheck className="h-10 w-10 text-blue-600 mx-auto mb-2" />
@@ -264,7 +263,7 @@ export default function Login() {
               </button>
             </form>
           ) : (
-            // --- Original Email/Password Form ---
+            <>
             <form className="space-y-6" onSubmit={handleSubmit(handlePrimaryLogin)}> {/* Use handlePrimaryLogin */}
               <div>
                 <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
@@ -538,8 +537,10 @@ export default function Login() {
               </div>
             </div>
           </div>
+        </>
+        )}
 
-          {/* Footer */}
+        {/* Footer */}
           <div className="mt-8 pt-6 border-t border-gray-200 text-center">
             <p className="text-xs text-gray-500">
               © 2024 PointFlex SaaS - Solution de pointage intelligente


### PR DESCRIPTION
## Summary
- expose `checkServerStatus` in `AuthContext`
- remove invalid inline comments in Login page
- wrap login alternative JSX in fragment to avoid syntax errors

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c465ac68c8332b76b159fcc79f1b0