### PR TITLE
Fix user creation order in init_db

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -213,11 +213,8 @@ def init_db():
             # Créer l'utilisateur sans le mot de passe dans le constructeur
             user = User(**user_data)
 
-            # Ajouter l'utilisateur à la session pour obtenir un ID
-            db.session.add(user)
-            db.session.flush()
-
-            # Définir le mot de passe séparément (mettra à jour l'historique)
+            # Définir le mot de passe avant d'insérer en base
+            # `set_password` ajoute l'utilisateur à la session et flush si nécessaire
             user.set_password(password)
         
         # Créer les paramètres système par défaut


### PR DESCRIPTION
## Summary
- avoid flushing users with empty password_hash during DB initialization

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686c4fe878808332af3c26e01284ec91