### PR TITLE
Add env var warnings and improve docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,11 +33,11 @@ STRIPE_API_KEY=your-stripe-key
 STRIPE_WEBHOOK_SECRET=your-webhook-secret
 
 # Firebase Cloud Messaging (FCM)
-FCM_SERVER_KEY=your_fcm_server_key_here # Replace with your FCM server key for push notifications
+FCM_SERVER_KEY=your_fcm_server_key_here # Required for push notifications
 
 # Two-Factor Authentication (2FA) Encryption Key
 # Generate using: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-TWO_FACTOR_ENCRYPTION_KEY=your_32_byte_url_safe_base64_encoded_key_here
+TWO_FACTOR_ENCRYPTION_KEY=your_32_byte_url_safe_base64_encoded_key_here # Required for 2FA encryption
 
 # Enhanced Password Policy (Optional - defaults exist in config.py)
 # PASSWORD_MIN_LENGTH=8
@@ -51,9 +51,10 @@ TWO_FACTOR_ENCRYPTION_KEY=your_32_byte_url_safe_base64_encoded_key_here
 # WEBHOOK_TIMEOUT_SECONDS=10
 # WEBHOOK_MAX_RETRIES=3
 
-# Rate Limiting (Optional - defaults exist in config.py)
-# RATELIMIT_ENABLED=True
-# RATELIMIT_STORAGE_URL=redis://localhost:6379/2  # Use a different Redis DB if possible
+# Rate Limiting
+# Uncomment and adjust for production. Using Redis is strongly recommended.
+RATELIMIT_ENABLED=True
+RATELIMIT_STORAGE_URL=redis://localhost:6379/2  # Use a different Redis DB if possible
 # RATELIMIT_STRATEGY=fixed-window
 # RATELIMIT_DEFAULT=200 per day;50 per hour;20 per minute
 # RATELIMIT_AUTH_LOGIN=20 per minute;50 per hour

--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ SECRET_KEY=votre-cle-secrete-unique-et-longue
 JWT_SECRET_KEY=votre-cle-jwt-secrete-unique
 DATABASE_URL=sqlite:///instance/pointflex.db
 CORS_ORIGINS=https://votre-domaine.com
+FCM_SERVER_KEY=votre-cle-fcm  # Necessaire pour les notifications push
+TWO_FACTOR_ENCRYPTION_KEY=votre-cle-fernet-32-bytes  # Obligatoire pour le chiffrement 2FA
+RATELIMIT_STORAGE_URL=redis://localhost:6379/2  # Configurez Redis pour Flask-Limiter
 ```
 
 ### CI/CD avec GitHub Actions

--- a/backend/app.py
+++ b/backend/app.py
@@ -45,6 +45,14 @@ def create_app():
     
     # Load configuration
     app.config.from_object(Config)
+
+    # Warn if critical environment variables are missing
+    if not app.config.get('FCM_SERVER_KEY'):
+        app.logger.warning('FCM_SERVER_KEY is not set. Push notifications will be disabled.')
+    if not app.config.get('TWO_FACTOR_ENCRYPTION_KEY'):
+        app.logger.warning('TWO_FACTOR_ENCRYPTION_KEY is not configured. 2FA encryption will fail.')
+    if app.config.get('RATELIMIT_STORAGE_URL', '').startswith('memory'):
+        app.logger.warning('RATELIMIT_STORAGE_URL uses local memory. Configure Redis for production use.')
     
     # Initialize CORS
     CORS(app, origins=["http://localhost:5173", "https://localhost:5173"])

--- a/backend/config.py
+++ b/backend/config.py
@@ -34,6 +34,9 @@ class Config:
     MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS', 'true').lower() in ['true', 'on', '1']
     MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
     MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
+
+    # Push Notifications
+    FCM_SERVER_KEY = os.environ.get('FCM_SERVER_KEY')
     
     # Limites système
     MAX_COMPANIES = 1000


### PR DESCRIPTION
## Summary
- highlight FCM and 2FA keys in example env file
- recommend Redis for rate limiting in env example
- warn at startup when important keys are missing
- document the required keys in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686ce9596f488332b2df4356dc7a1a27