### PR TITLE
Configure Redis for SSE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ TWO_FACTOR_ENCRYPTION_KEY=your_32_byte_url_safe_base64_encoded_key_here # Requir
 # PASSWORD_REQUIRE_SPECIAL_CHAR=True
 # PASSWORD_HISTORY_COUNT=5
 
+# Redis configuration (SSE, rate limiting, task queues)
+REDIS_URL=redis://localhost:6379/0
+
 # Webhook Configuration (Optional)
 # WEBHOOK_SIGNATURE_HEADER_NAME=X-PointFlex-Signature-256
 # WEBHOOK_TIMEOUT_SECONDS=10

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ cd backend && python app.py  # Backend sur :5000
 ```bash
 docker-compose -f docker-compose.dev.yml up
 ```
+Ce fichier compose lance désormais un service **redis** indispensable pour les notifications en temps réel (SSE) et la limitation de débit.
 
 ### Variables d'Environnement
 
@@ -279,6 +280,7 @@ SECRET_KEY=your-secret-key-here
 JWT_SECRET_KEY=your-jwt-secret-key-here
 DATABASE_URL=sqlite:///instance/pointflex.db
 CORS_ORIGINS=http://localhost,https://yourdomain.com
+REDIS_URL=redis://localhost:6379/0
 ```
 
 ### Production (Serveur)
@@ -296,6 +298,8 @@ nano .env  # Modifier les clés secrètes
 # Déployer
 docker-compose up -d
 
+Cette configuration inclut également un service **redis** nécessaire au bon fonctionnement des notifications SSE et du système de tâches.
+
 # Configurer un reverse proxy (Nginx recommandé)
 ```
 
@@ -308,6 +312,7 @@ DATABASE_URL=sqlite:///instance/pointflex.db
 CORS_ORIGINS=https://votre-domaine.com
 FCM_SERVER_KEY=votre-cle-fcm  # Necessaire pour les notifications push
 TWO_FACTOR_ENCRYPTION_KEY=votre-cle-fernet-32-bytes  # Obligatoire pour le chiffrement 2FA
+REDIS_URL=redis://localhost:6379/0
 RATELIMIT_STORAGE_URL=redis://localhost:6379/2  # Configurez Redis pour Flask-Limiter
 ```
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,9 +18,18 @@ services:
       - FLASK_ENV=development
       - FLASK_DEBUG=1
       - DATABASE_URL=sqlite:///instance/pointflex.db
+      - REDIS_URL=redis://redis:6379/0
     volumes:
       - ./backend:/app
       - ./backend/instance:/app/instance
+    networks:
+      - pointflex-dev
+
+  redis:
+    image: redis:7
+    restart: always
+    ports:
+      - "6379:6379"
     networks:
       - pointflex-dev
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,17 @@ services:
     environment:
       - FLASK_ENV=production
       - DATABASE_URL=sqlite:///instance/pointflex.db
+      - REDIS_URL=redis://redis:6379/0
     volumes:
       - ./backend/instance:/app/instance
+    networks:
+      - pointflex-network
+
+  redis:
+    image: redis:7
+    restart: always
+    ports:
+      - "6379:6379"
     networks:
       - pointflex-network
 


### PR DESCRIPTION
## Summary
- add a Redis container in both compose files
- expose REDIS_URL env var for the backend
- document Redis requirement in README and `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2208f25c8332befd062859a4c553