### PR TITLE
Add arrival equalization support

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -56,7 +56,8 @@ def init_db():
                 'subscription_status': 'active',
                 'max_employees': 50,
                 'is_active': True,
-                'notes': 'Entreprise de démonstration pour PointFlex'
+                'notes': 'Entreprise de démonstration pour PointFlex',
+                'equalization_threshold': 5
             },
             {
                 'name': 'TechCorp Solutions',
@@ -72,7 +73,8 @@ def init_db():
                 'subscription_status': 'active',
                 'max_employees': 200,
                 'is_active': True,
-                'notes': 'Grande entreprise technologique'
+                'notes': 'Grande entreprise technologique',
+                'equalization_threshold': 5
             }
         ]
         

--- a/backend/models/company.py
+++ b/backend/models/company.py
@@ -35,6 +35,8 @@ class Company(db.Model):
     office_radius = db.Column(db.Integer, default=100)  # mètres
     work_start_time = db.Column(db.Time, default=datetime.strptime('09:00', '%H:%M').time())
     late_threshold = db.Column(db.Integer, default=15)  # minutes
+    # Minutes de tolérance pour l'égalisation de l'heure d'arrivée
+    equalization_threshold = db.Column(db.Integer, default=0)
 
     # Personnalisation d'entreprise
     logo_url = db.Column(db.String(255), nullable=True)
@@ -175,6 +177,7 @@ class Company(db.Model):
                 'office_radius': self.office_radius,
                 'work_start_time': self.work_start_time.strftime('%H:%M') if self.work_start_time else None,
                 'late_threshold': self.late_threshold,
+                'equalization_threshold': self.equalization_threshold,
                 'work_days': self.work_days, # Add new leave policy fields
                 'default_country_code_for_holidays': self.default_country_code_for_holidays, # Add new leave policy fields
                 'plan_limits': self.get_plan_limits(),

--- a/backend/models/pointage.py
+++ b/backend/models/pointage.py
@@ -34,6 +34,9 @@ class Pointage(db.Model):
     
     # Mission (pour pointage mission)
     mission_order_number = db.Column(db.String(100), nullable=True)
+
+    # Indique si l'heure d'arrivée a été égalisée au début de journée
+    is_equalized = db.Column(db.Boolean, default=False)
     
     # Métadonnées
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
@@ -78,6 +81,12 @@ class Pointage(db.Model):
             self.statut = 'present'
         else:
             self.statut = 'retard'
+
+        # Appliquer l'égalisation si configurée
+        equal_thresh = getattr(company, 'equalization_threshold', 0)
+        if 0 < delay_minutes <= equal_thresh:
+            self.heure_arrivee = work_start
+            self.is_equalized = True
     
     def calculate_worked_hours(self):
         """Calcule les heures travaillées si heure de départ renseignée"""
@@ -125,6 +134,7 @@ class Pointage(db.Model):
             'mission_order_number': self.mission_order_number,
             'worked_hours': self.calculate_worked_hours(),
             'delay_minutes': self.delay_minutes,
+            'is_equalized': self.is_equalized,
             'created_at': self.created_at.isoformat(),
             'updated_at': self.updated_at.isoformat()
         }

--- a/backend/tests/test_attendance.py
+++ b/backend/tests/test_attendance.py
@@ -15,6 +15,7 @@ def test_office_checkin(client):
     assert resp.status_code == 201
     body = resp.get_json()
     assert body['pointage']['type'] == 'office'
+    assert 'is_equalized' in body['pointage']
 
 
 def test_get_attendance_stats(client):


### PR DESCRIPTION
## Summary
- add `equalization_threshold` to company model
- mark pointages as equalized when arrival is close to official start
- expose equalized flag in API responses
- seed default companies with a threshold
- update attendance test to expect the flag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d41304ef08332b976178d9b388328