### PR TITLE
Fix SQLAlchemy instance mismatch in backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from config import Config
 
 # Import database
-from database import db, init_db
+from backend.database import db, init_db
 
 # Import route blueprints
 from routes.auth_routes import auth_bp

--- a/backend/cli_commands.py
+++ b/backend/cli_commands.py
@@ -2,7 +2,7 @@ import click
 from flask.cli import with_appcontext
 from datetime import datetime, date
 
-from database import db
+from backend.database import db
 from backend.models.user import User
 from backend.models.leave_type import LeaveType
 from backend.models.leave_balance import LeaveBalance

--- a/backend/middleware/audit.py
+++ b/backend/middleware/audit.py
@@ -4,7 +4,7 @@ Middleware d'audit automatique
 
 from flask import request, g
 from backend.models.audit_log import AuditLog
-from database import db
+from backend.database import db
 from datetime import datetime
 
 def init_audit_middleware(app):

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -7,7 +7,7 @@ from flask_jwt_extended import verify_jwt_in_request, get_jwt_identity, get_jwt
 from functools import wraps
 from backend.models.user import User
 from backend.models.audit_log import AuditLog
-from database import db
+from backend.database import db
 
 def init_auth_middleware(app, jwt):
     """Initialise le middleware d'authentification"""

--- a/backend/middleware/error_handler.py
+++ b/backend/middleware/error_handler.py
@@ -6,7 +6,7 @@ from flask import jsonify, request
 from werkzeug.exceptions import HTTPException
 from sqlalchemy.exc import SQLAlchemyError
 from backend.models.audit_log import AuditLog
-from database import db
+from backend.database import db
 import traceback
 
 def init_error_handlers(app):

--- a/backend/models/audit_log.py
+++ b/backend/models/audit_log.py
@@ -2,7 +2,7 @@
 Modèle AuditLog - Journalisation des actions utilisateurs
 """
 
-from database import db
+from backend.database import db
 from datetime import datetime
 import json
 

--- a/backend/models/company.py
+++ b/backend/models/company.py
@@ -2,7 +2,7 @@
 Modèle Company - Gestion des entreprises
 """
 
-from database import db
+from backend.database import db
 from datetime import datetime, timedelta
 
 class Company(db.Model):

--- a/backend/models/company_holiday.py
+++ b/backend/models/company_holiday.py
@@ -1,7 +1,7 @@
 """
 CompanyHoliday Model - Stores company-specific holidays
 """
-from database import db # Assuming database.py is in the root of 'backend'
+from backend.database import db # Assuming database.py is in the root of 'backend'
 from datetime import datetime
 
 class CompanyHoliday(db.Model):

--- a/backend/models/department.py
+++ b/backend/models/department.py
@@ -1,7 +1,7 @@
 """Department model for company organization structure."""
 
 from datetime import datetime
-from database import db
+from backend.database import db
 
 
 class Department(db.Model):

--- a/backend/models/invoice.py
+++ b/backend/models/invoice.py
@@ -2,7 +2,7 @@
 Model Invoice - Gestion de la facturation des abonnements
 """
 
-from database import db
+from backend.database import db
 from datetime import datetime
 
 class Invoice(db.Model):

--- a/backend/models/leave_balance.py
+++ b/backend/models/leave_balance.py
@@ -1,7 +1,7 @@
 """
 LeaveBalance Model - Tracks available leave for users
 """
-from database import db # Corrected import path
+from backend.database import db # Corrected import path
 from datetime import datetime
 
 class LeaveBalance(db.Model):

--- a/backend/models/leave_request.py
+++ b/backend/models/leave_request.py
@@ -1,7 +1,7 @@
 """
 LeaveRequest Model - Represents an employee's request for leave
 """
-from database import db # Corrected import path
+from backend.database import db # Corrected import path
 from datetime import datetime, date, timedelta # Added timedelta
 import holidays # For calculating workdays, may need to add to requirements.txt
 from .user import User  # Added User import

--- a/backend/models/leave_type.py
+++ b/backend/models/leave_type.py
@@ -1,7 +1,7 @@
 """
 LeaveType Model - Defines different types of leave available
 """
-from database import db # Corrected import path
+from backend.database import db # Corrected import path
 from datetime import datetime
 
 class LeaveType(db.Model):

--- a/backend/models/mission.py
+++ b/backend/models/mission.py
@@ -1,6 +1,6 @@
 """Mission model for managing mission orders"""
 
-from database import db
+from backend.database import db
 from .mission_user import MissionUser
 from datetime import datetime
 

--- a/backend/models/mission_user.py
+++ b/backend/models/mission_user.py
@@ -1,4 +1,4 @@
-from database import db
+from backend.database import db
 from datetime import datetime
 
 class MissionUser(db.Model):

--- a/backend/models/notification.py
+++ b/backend/models/notification.py
@@ -2,7 +2,7 @@
 Notification Model - Gestion des notifications utilisateur
 """
 
-from database import db
+from backend.database import db
 from datetime import datetime
 
 class Notification(db.Model):

--- a/backend/models/office.py
+++ b/backend/models/office.py
@@ -2,7 +2,7 @@
 Modèle Office - Gestion des bureaux et sites
 """
 
-from database import db
+from backend.database import db
 from datetime import datetime
 import json
 

--- a/backend/models/password_history.py
+++ b/backend/models/password_history.py
@@ -1,7 +1,7 @@
 """
 PasswordHistory Model - Stores recent password hashes for users to prevent reuse.
 """
-from database import db
+from backend.database import db
 from datetime import datetime
 
 class PasswordHistory(db.Model):

--- a/backend/models/payment.py
+++ b/backend/models/payment.py
@@ -2,7 +2,7 @@
 Model Payment - Enregistrement des paiements
 """
 
-from database import db
+from backend.database import db
 from datetime import datetime
 
 class Payment(db.Model):

--- a/backend/models/pointage.py
+++ b/backend/models/pointage.py
@@ -2,7 +2,7 @@
 Modèle Pointage - Gestion des pointages
 """
 
-from database import db
+from backend.database import db
 from datetime import datetime, time
 
 class Pointage(db.Model):

--- a/backend/models/position.py
+++ b/backend/models/position.py
@@ -1,7 +1,7 @@
 """Position model for employee roles."""
 
 from datetime import datetime
-from database import db
+from backend.database import db
 
 
 class Position(db.Model):

--- a/backend/models/push_subscription.py
+++ b/backend/models/push_subscription.py
@@ -1,7 +1,7 @@
 """
 PushSubscription Model - Manages device tokens for push notifications
 """
-from database import db
+from backend.database import db
 from datetime import datetime
 
 class PushSubscription(db.Model):

--- a/backend/models/service.py
+++ b/backend/models/service.py
@@ -1,7 +1,7 @@
 """Service model belonging to a department."""
 
 from datetime import datetime
-from database import db
+from backend.database import db
 
 
 class Service(db.Model):

--- a/backend/models/system_settings.py
+++ b/backend/models/system_settings.py
@@ -2,7 +2,7 @@
 Modèle SystemSettings - Paramètres système configurables
 """
 
-from database import db
+from backend.database import db
 from datetime import datetime
 import json
 
@@ -108,7 +108,7 @@ class SystemSettings(db.Model):
         cls.query.delete()
         
         # Recréer les paramètres par défaut
-        from database import init_db
+        from backend.database import init_db
         # Note: Cette méthode nécessiterait une refactorisation pour éviter la dépendance circulaire
         
     def to_dict(self):
@@ -123,5 +123,4 @@ class SystemSettings(db.Model):
             'updated_at': self.updated_at.isoformat()
         }
     
-    def __repr__(self):
-        return f'<SystemSettings {self.category}.{self.key}>'
+    def __repr__(self):        return f'<SystemSettings {self.category}.{self.key}>'

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -2,7 +2,7 @@
 Modèle User - Gestion des utilisateurs
 """
 
-from database import db
+from backend.database import db
 from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime
 import secrets

--- a/backend/models/webhook_delivery_log.py
+++ b/backend/models/webhook_delivery_log.py
@@ -1,7 +1,7 @@
 """
 WebhookDeliveryLog Model - Logs attempts to deliver webhooks
 """
-from database import db # Corrected import
+from backend.database import db # Corrected import
 from datetime import datetime
 import json
 

--- a/backend/models/webhook_subscription.py
+++ b/backend/models/webhook_subscription.py
@@ -1,7 +1,7 @@
 """
 WebhookSubscription Model - Manages webhook configurations for companies
 """
-from database import db # Corrected import
+from backend.database import db # Corrected import
 from datetime import datetime
 import secrets # For generating secrets
 import hmac

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -21,7 +21,7 @@ from reportlab.lib.units import inch # Keep only what's directly used here
 # Removed other direct reportlab imports as they are now in pdf_utils
 from datetime import datetime
 from backend.utils.pdf_utils import build_pdf_document, create_styled_table, get_report_styles, generate_report_title_elements
-from database import db
+from backend.database import db
 import json
 from flask import current_app # Added for FRONTEND_URL
 

--- a/backend/routes/attendance_routes.py
+++ b/backend/routes/attendance_routes.py
@@ -11,7 +11,7 @@ from backend.models.pointage import Pointage
 from backend.models.user import User
 from backend.models.mission import Mission
 from backend.models.office import Office
-from database import db
+from backend.database import db
 from datetime import datetime, date, timedelta
 import math
 

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -8,7 +8,7 @@ from backend.models.user import User
 from backend.models.audit_log import AuditLog
 from middleware.auth import get_current_user
 from middleware.audit import log_user_action
-from database import db
+from backend.database import db
 from datetime import datetime
 from extensions import limiter
 

--- a/backend/routes/health_routes.py
+++ b/backend/routes/health_routes.py
@@ -4,7 +4,7 @@ Routes de santé et monitoring
 
 from flask import Blueprint, jsonify
 from datetime import datetime
-from database import db
+from backend.database import db
 from backend.models.user import User
 from backend.models.company import Company
 from backend.models.pointage import Pointage

--- a/backend/routes/mission_routes.py
+++ b/backend/routes/mission_routes.py
@@ -6,7 +6,7 @@ from middleware.auth import get_current_user, require_admin
 from backend.models.mission import Mission
 from backend.models.mission_user import MissionUser
 from backend.models.user import User
-from database import db
+from backend.database import db
 from backend.middleware.audit import log_user_action # Added for audit logging
 from flask import current_app # For logging
 

--- a/backend/routes/profile_routes.py
+++ b/backend/routes/profile_routes.py
@@ -6,7 +6,7 @@ from flask import Blueprint, request, jsonify, send_file, current_app
 from flask_jwt_extended import jwt_required
 from middleware.auth import get_current_user
 from middleware.audit import log_user_action
-from database import db
+from backend.database import db
 from backend.models.pointage import Pointage
 from backend.models.leave_request import LeaveRequest
 from backend.utils.pdf_utils import (

--- a/backend/routes/superadmin_routes.py
+++ b/backend/routes/superadmin_routes.py
@@ -14,7 +14,7 @@ from backend.models.audit_log import AuditLog
 from backend.models.invoice import Invoice
 from backend.models.payment import Payment
 from services.stripe_service import create_checkout_session, verify_webhook
-from database import db
+from backend.database import db
 from datetime import datetime, timedelta
 import json
 

--- a/backend/utils/webhook_utils.py
+++ b/backend/utils/webhook_utils.py
@@ -6,7 +6,7 @@ import requests
 from datetime import datetime, timedelta
 from flask import current_app
 
-from database import db # Corrected import
+from backend.database import db # Corrected import
 from backend.models.webhook_subscription import WebhookSubscription # This import is fine as it's a sibling package
 from backend.models.webhook_delivery_log import WebhookDeliveryLog # This import is fine
 


### PR DESCRIPTION
## Summary
- ensure all backend modules import `db` from `backend.database`
- update app factory to use same import path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test --silent` *(fails: jest: not found)*
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e5607e0408332a4c333ea1a6c67f4