### PR TITLE
Add leave permission checks

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -114,4 +114,5 @@ def create_app():
 app = create_app()
 
 if __name__ == '__main__':
-    port = int(os.environ.get('PORT', 5000))    app.run(host='0.0.0.0', port=port, debug=True)
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port, debug=True)

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -119,7 +119,7 @@ def require_admin(f):
 
 def require_superadmin_or_admin(f):
     """Décorateur pour exiger le rôle SuperAdmin ou Admin RH"""
-    return require_admin(f)
+    return require_role(['superadmin', 'admin_rh'])(f)
 
 def require_manager_or_above(f):
     """Décorateur pour exiger un rôle manager ou supérieur"""

--- a/backend/routes/leave_routes.py
+++ b/backend/routes/leave_routes.py
@@ -37,9 +37,8 @@ def list_leave_types():
     return jsonify([lt.to_dict() for lt in leave_types]), 200
 
 @leave_bp.route('/types', methods=['POST'])
-@jwt_required() # require_superadmin_or_admin would be better
+@require_superadmin_or_admin
 def create_leave_type():
-    # TODO: Add role check (SuperAdmin or Company Admin)
     current_user = get_current_user()
     data = request.get_json()
 
@@ -522,9 +521,6 @@ def admin_adjust_user_leave_balance(user_id):
         return jsonify(message="Failed to adjust leave balance."), 500
 
 
-# TODO: Add a decorator @require_superadmin_or_admin for type creation/management.
-# For now, using @jwt_required() and manual role checks.
-# def require_superadmin_or_admin(fn):
 
 @leave_bp.route('/calculate-duration', methods=['POST'])
 @jwt_required()

--- a/backend/tests/test_leave_routes.py
+++ b/backend/tests/test_leave_routes.py
@@ -1,0 +1,16 @@
+from backend.tests.test_admin_routes import login_manager
+from backend.tests.test_attendance import login_employee
+
+
+def test_create_leave_type_denied_for_employee(client):
+    token = login_employee(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.post("/api/leave/types", json={"name": "RTT"}, headers=headers)
+    assert resp.status_code == 403
+
+
+def test_create_leave_type_denied_for_manager(client):
+    token = login_manager(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.post("/api/leave/types", json={"name": "RTT"}, headers=headers)
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- check for superadmin or admin when creating leave types
- implement `require_superadmin_or_admin` decorator
- fix newline in `app.py`
- test that non-admin roles get 403 when creating leave types

## Testing
- `pytest backend/tests/test_leave_routes.py::test_create_leave_type_denied_for_employee -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686fa981f7508332a0ecd201d5851eb7