### PR TITLE
Prevent circular manager assignments

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -195,3 +195,27 @@ class User(db.Model):
     
     def __repr__(self):
         return f'<User {self.email}>'
+
+    @staticmethod
+    def would_create_manager_cycle(employee_id: int, new_manager_id: int) -> bool:
+        """Return True if assigning ``new_manager_id`` as manager of ``employee_id``
+        would introduce a management cycle."""
+
+        if employee_id == new_manager_id:
+            return True
+
+        manager = User.query.get(new_manager_id)
+        visited = set()
+
+        # Walk up the management chain from the potential manager. If we
+        # encounter the employee or loop back to a visited user, a cycle would
+        # be created.
+        while manager:
+            if manager.id == employee_id:
+                return True
+            if manager.id in visited:
+                return True
+            visited.add(manager.id)
+            manager = manager.manager
+
+        return False

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -1300,7 +1300,9 @@ def set_employee_manager(employee_id):
             return jsonify(message=f"Manager avec ID {new_manager_id} non trouvé."), 404
         if new_manager.company_id != current_admin.company_id:
             return jsonify(message="Le manager sélectionné n'appartient pas à la même entreprise."), 403
-        # TODO: Check for circular dependencies (e.g., A manages B, B manages A) - more complex logic needed
+        # Prevent circular management relations
+        if User.would_create_manager_cycle(employee_id, new_manager_id):
+            return jsonify(message="Cette relation de gestion créerait une boucle."), 400
 
         target_employee.manager_id = new_manager_id
         new_values_details = {'manager_id': new_manager_id, 'manager_name': f"{new_manager.prenom} {new_manager.nom}"}


### PR DESCRIPTION
## Summary
- detect manager cycles before saving
- add static helper to `User` for cycle detection
- test manager cycle prevention

## Testing
- `pytest -q backend/tests/test_admin_routes.py::test_prevent_manager_cycle` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686fb49f30c48332af3583d474f6b864