### PR TITLE
Add iCal export button to TeamCalendar

### DIFF
--- a/src/components/TeamCalendar.test.tsx
+++ b/src/components/TeamCalendar.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import TeamCalendar from './TeamCalendar';
+import { calendarService, adminService } from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../services/api', () => ({
+  calendarService: {
+    getCalendarEvents: jest.fn(),
+    downloadICal: jest.fn()
+  },
+  adminService: {
+    getEmployees: jest.fn()
+  }
+}));
+
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: jest.fn()
+}));
+
+const mockedCalendarService = calendarService as jest.Mocked<typeof calendarService>;
+const mockedUseAuth = useAuth as jest.Mock;
+const mockedAdminService = adminService as jest.Mocked<typeof adminService>;
+
+beforeEach(() => {
+  mockedUseAuth.mockReturnValue({ user: { id: 1 }, isAdmin: false });
+  mockedCalendarService.getCalendarEvents.mockResolvedValue({ data: [] });
+  mockedCalendarService.downloadICal.mockResolvedValue({ data: new Blob(['a']) });
+  mockedAdminService.getEmployees.mockResolvedValue({ data: [] });
+});
+
+describe('TeamCalendar iCal export', () => {
+  test('renders export iCal button', () => {
+    render(<TeamCalendar />);
+    expect(screen.getByRole('button', { name: /export ical/i })).toBeInTheDocument();
+  });
+
+  test('calls downloadICal on click', () => {
+    render(<TeamCalendar />);
+    const btn = screen.getByRole('button', { name: /export ical/i });
+    fireEvent.click(btn);
+    expect(mockedCalendarService.downloadICal).toHaveBeenCalled();
+  });
+});

--- a/src/components/TeamCalendar.tsx
+++ b/src/components/TeamCalendar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
-import { 
-  Calendar, 
-  ChevronLeft, 
+import {
+  Calendar,
+  ChevronLeft,
   ChevronRight,
   Users,
   Clock,
@@ -9,6 +9,7 @@ import {
   Filter,
   Briefcase, // For mission type
   Home, // For office type
+  Download,
   Sunrise, Sunset, Sun, Moon // For half-day leave indicators
 } from 'lucide-react';
 import {
@@ -122,6 +123,25 @@ export default function TeamCalendar() {
     );
   };
 
+  const handleDownloadICal = async () => {
+    if (!calendarService.downloadICal) {
+      toast.error('Export iCal non disponible');
+      return;
+    }
+    try {
+      const resp = await calendarService.downloadICal();
+      const url = window.URL.createObjectURL(new Blob([resp.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'events.ics');
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (error) {
+      toast.error("Erreur lors de l'export iCal");
+    }
+  };
+
 
   const monthStart = startOfMonth(currentDate);
   const monthEnd = endOfMonth(currentDate);
@@ -161,7 +181,9 @@ export default function TeamCalendar() {
           <h1 className="text-2xl font-bold text-gray-900">Calendrier d'Équipe</h1>
           <p className="text-gray-600">Vue d'ensemble des activités de l'équipe.</p>
         </div>
-        {/* TODO: Add button for iCal export here */}
+        <button onClick={handleDownloadICal} className="btn-secondary flex items-center">
+          <Download className="h-4 w-4 mr-2" /> Export iCal
+        </button>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -455,6 +455,15 @@ export const calendarService = {
       console.error('Get calendar events service error:', error);
       throw error;
     }
+  },
+  downloadICal: async () => {
+    try {
+      console.log('📅 Téléchargement du calendrier des événements...');
+      return await api.get('/calendar/events/ical', { responseType: 'blob' });
+    } catch (error) {
+      console.error('Download calendar iCal service error:', error);
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- add download icon to TeamCalendar and implement export button
- implement `calendarService.downloadICal` API helper
- connect button to download function
- add unit tests for export button

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc310bb88332bb4cdb21bcebe551