### PR TITLE
Fix edit form selection fields

### DIFF
--- a/src/components/EmployeeManagement.test.tsx
+++ b/src/components/EmployeeManagement.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import EmployeeManagement from './EmployeeManagement';
+import { adminService } from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../services/api', () => ({
+  adminService: {
+    getEmployees: jest.fn(),
+    getOrganizationData: jest.fn(),
+  }
+}));
+
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: jest.fn()
+}));
+
+const mockedAdminService = adminService as jest.Mocked<typeof adminService>;
+const mockedUseAuth = useAuth as jest.Mock;
+
+beforeEach(() => {
+  mockedUseAuth.mockReturnValue({ isAdmin: true, isSuperAdmin: false });
+});
+
+const employees = [
+  {
+    id: 1,
+    email: 'john@example.com',
+    nom: 'Doe',
+    prenom: 'John',
+    role: 'employee',
+    is_active: true,
+    employee_number: 'E1',
+    phone: '123',
+    department_name: 'IT',
+    service_name: 'Dev',
+    position_name: 'Engineer',
+    manager_id: null,
+    manager_name: null,
+    company_name: 'ACME',
+    created_at: '2024-01-01'
+  }
+];
+
+const orgData = {
+  departments: [{ id: 2, name: 'IT' }],
+  services: [{ id: 10, name: 'Dev', department_id: 2 }],
+  positions: [{ id: 20, name: 'Engineer' }]
+};
+
+
+test('prefills organization fields when editing an employee', async () => {
+  mockedAdminService.getEmployees.mockResolvedValue({ data: employees });
+  mockedAdminService.getOrganizationData.mockResolvedValue({ data: orgData });
+
+  render(<EmployeeManagement />);
+
+  await waitFor(() => expect(screen.getByText('John Doe')).toBeInTheDocument());
+
+  fireEvent.click(screen.getByTitle('Modifier Employé'));
+
+  await screen.findByText("Modifier l'employé");
+
+  const deptOption = screen.getByRole('option', { name: 'IT' }) as HTMLOptionElement;
+  const serviceOption = screen.getByRole('option', { name: 'Dev' }) as HTMLOptionElement;
+  const positionOption = screen.getByRole('option', { name: 'Engineer' }) as HTMLOptionElement;
+
+  expect(deptOption.selected).toBe(true);
+  expect(serviceOption.selected).toBe(true);
+  expect(positionOption.selected).toBe(true);
+});

--- a/src/components/EmployeeManagement.tsx
+++ b/src/components/EmployeeManagement.tsx
@@ -181,13 +181,21 @@ export default function EmployeeManagement() {
 
   const startEdit = (emp: Employee) => {
     setEditingEmployee(emp)
+    const dept = orgData?.departments?.find((d: any) => d.name === emp.department_name)
+    const service = orgData?.services?.find((s: any) => s.name === emp.service_name)
+    const position = orgData?.positions?.find((p: any) => p.name === emp.position_name)
+
     setForm({
-      email: emp.email, nom: emp.nom, prenom: emp.prenom, role: emp.role,
-      password: '', phone: emp.phone || '',
-      department_id: '', // TODO: Populate these from emp if available and needed for edit
-      service_id: '',
-      position_id: '',
-      manager_id: emp.manager_id ? String(emp.manager_id) : '' // Populate manager_id
+      email: emp.email,
+      nom: emp.nom,
+      prenom: emp.prenom,
+      role: emp.role,
+      password: '',
+      phone: emp.phone || '',
+      department_id: dept ? String(dept.id) : '',
+      service_id: service ? String(service.id) : '',
+      position_id: position ? String(position.id) : '',
+      manager_id: emp.manager_id ? String(emp.manager_id) : ''
     })
     setShowModal(true)
   }


### PR DESCRIPTION
## Summary
- populate department, service and position when editing an employee
- test edit workflow for organization fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbdb1006083329f4eb401b3db05b2