### PR TITLE
Add RQ worker script

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -24,8 +24,11 @@ chmod +x quick-install.sh && ./quick-install.sh
 cd backend
 python app.py
 
-# Terminal 2 - Frontend  
+# Terminal 2 - Frontend
 npm run dev
+
+# Terminal 3 - RQ Worker (webhooks)
+python run_worker.py
 ```
 
 **Accès:**
@@ -110,6 +113,9 @@ nano .env  # Modifier les clés secrètes
 
 # Déployer
 docker-compose up -d
+
+# Démarrer ensuite le worker RQ pour les webhooks
+docker-compose exec backend python run_worker.py
 ```
 
 ### Option 2: Hébergement Gratuit

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ docker-compose up --build -d
 # Ensuite démarrer les services
 npm run dev                # Frontend sur :5173
 cd backend && python app.py  # Backend sur :5000
+python run_worker.py         # Worker RQ pour les webhooks
 ```
 
 #### Ou avec Docker
@@ -302,6 +303,9 @@ nano .env  # Modifier les clés secrètes
 
 # Déployer
 docker-compose up -d
+
+# Démarrer ensuite le worker RQ pour les webhooks
+docker-compose exec backend python run_worker.py
 
 Cette configuration inclut également un service **redis** nécessaire au bon fonctionnement des notifications SSE et du système de tâches.
 

--- a/backend/utils/webhook_utils.py
+++ b/backend/utils/webhook_utils.py
@@ -10,6 +10,9 @@ from backend.database import db # Corrected import
 from backend.models.webhook_subscription import WebhookSubscription # This import is fine as it's a sibling package
 from backend.models.webhook_delivery_log import WebhookDeliveryLog # This import is fine
 
+# Queue name used for webhook dispatch jobs
+WEBHOOK_QUEUE_NAME = "pointflex_webhooks"
+
 # Configuration for webhook delivery
 WEBHOOK_TIMEOUT_SECONDS = 10
 WEBHOOK_MAX_RETRIES = 3 # For a more advanced system; initial implementation might not auto-retry
@@ -67,7 +70,7 @@ def dispatch_webhook_event(event_type: str, payload_data: dict, company_id: int 
         redis_url = current_app.config.get('REDIS_URL', os.environ.get('REDIS_URL', 'redis://localhost:6379/0'))
         redis_conn = Redis.from_url(redis_url)
         # Using a dedicated queue for webhooks
-        webhook_queue = Queue("pointflex_webhooks", connection=redis_conn)
+        webhook_queue = Queue(WEBHOOK_QUEUE_NAME, connection=redis_conn)
     except Exception as e:
         current_app.logger.error(f"Failed to connect to Redis for RQ: {e}. Webhooks will not be queued.")
         return

--- a/run_worker.py
+++ b/run_worker.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""Start an RQ worker with Flask app context."""
+import os
+from redis import Redis
+from rq import Worker, Connection
+
+from backend.app import create_app
+from backend.utils.webhook_utils import WEBHOOK_QUEUE_NAME
+
+
+def main():
+    app = create_app()
+    redis_url = app.config.get("REDIS_URL", os.environ.get("REDIS_URL", "redis://localhost:6379/0"))
+    conn = Redis.from_url(redis_url)
+
+    with app.app_context():
+        with Connection(conn):
+            worker = Worker([WEBHOOK_QUEUE_NAME])
+            worker.work()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `run_worker.py` to start RQ worker with Flask app
- expose queue name constant in `webhook_utils`
- document running the worker in deployment docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686fc1e9272c8332a5fdd1dcc313dc84