### PR TITLE
Fix duplicate attendance service

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -856,16 +856,6 @@ export const adminService = {
     }
   },
   
-  getCompanyAttendance: async (date?: string) => {
-    try {
-      console.log('🕒 Récupération des pointages de l\'entreprise...')
-      const params = date ? { date } : undefined
-      return await api.get('/attendance', { params })
-    } catch (error) {
-      console.error('Get company attendance service error:', error)
-      throw error
-    }
-  },
   
   getOffices: async () => {
     try {


### PR DESCRIPTION
## Summary
- remove duplicate `getCompanyAttendance` function

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686fd64a0ce48332ac2d0d837403f7f4