### PR TITLE
Fix Vite import meta typing

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -856,16 +856,6 @@ export const adminService = {
     }
   },
   
-  getCompanyAttendance: async (date?: string) => {
-    try {
-      console.log('🕒 Récupération des pointages de l\'entreprise...')
-      const params = date ? { date } : undefined
-      return await api.get('/attendance', { params })
-    } catch (error) {
-      console.error('Get company attendance service error:', error)
-      throw error
-    }
-  },
   
   getOffices: async () => {
     try {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary
- remove duplicate `getCompanyAttendance` service definition
- include Vite env types for `import.meta.env`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_e_686fd64a0ce48332ac2d0d837403f7f4