### PR TITLE
Fix admin attendance view

### DIFF
--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -105,7 +105,13 @@ export default function AdminDashboard() {
       case 'settings':
         return <CompanySettings />
       case 'attendance':
-        return <AttendanceHistory />
+        return (
+          <AttendanceHistory
+            fetchRecords={(start, end) =>
+              adminService.getCompanyAttendance({ startDate: start, endDate: end })
+            }
+          />
+        )
       case 'organization':
         return (
           <div className="space-y-6">


### PR DESCRIPTION
## Summary
- allow AttendanceHistory to use a custom fetch function
- use the custom fetch in AdminDashboard so admins see company attendance
- test admin attendance API endpoint

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687129fc95048332961dad8d8b6ad590