### PR TITLE
Fix admin route imports

### DIFF
--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -30,7 +30,7 @@ import os
 
 # Stripe utilities
 from backend.services import stripe_service
-from backend.routes.stripe_routes import get_stripe_price_to_plan_mapping, create_checkout_session
+from backend.routes.stripe_routes import get_stripe_price_to_plan_mapping
 
 
 admin_bp = Blueprint('admin', __name__)


### PR DESCRIPTION
## Summary
- fix invalid import in `admin_routes`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687134cc37048332ad75831b22a0355d