### PR TITLE
Fix TeamCalendar missing useEffect import

### DIFF
--- a/src/components/TeamCalendar.tsx
+++ b/src/components/TeamCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import {
   Calendar,
   ChevronLeft,


### PR DESCRIPTION
## Summary
- fix a ReferenceError by importing `useEffect` in TeamCalendar

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_687139c20f3883329d228196726340a4