### PR TITLE
Improve check-in error messages

### DIFF
--- a/src/pages/CheckIn.tsx
+++ b/src/pages/CheckIn.tsx
@@ -47,6 +47,9 @@ export default function CheckIn() {
     } catch (error: any) {
       if (error.message.includes('Géolocalisation')) {
         toast.error("Veuillez autoriser l'accès à votre position")
+      } else if (error.response?.data?.message) {
+        // Afficher le message d'erreur retourné par l'API (ex: trop loin du bureau)
+        toast.error(error.response.data.message)
       }
       // les autres erreurs sont gérées par l'intercepteur API
     } finally {
@@ -83,6 +86,9 @@ export default function CheckIn() {
     } catch (error: any) {
       if (error.message.includes('Géolocalisation')) {
         toast.error("Veuillez autoriser l'accès à votre position")
+      } else if (error.response?.data?.message) {
+        // Afficher le message d'erreur retourné par l'API (ex: mission non autorisée)
+        toast.error(error.response.data.message)
       }
       // autres erreurs gérées par l'intercepteur API
     } finally {


### PR DESCRIPTION
## Summary
- display API error message directly when check-in requests fail

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713da3adfc8332b46e6f9e6b3e82fb