### PR TITLE
Improve console error messages

### DIFF
--- a/src/pages/CheckIn.tsx
+++ b/src/pages/CheckIn.tsx
@@ -47,6 +47,9 @@ export default function CheckIn() {
     } catch (error: any) {
       if (error.message.includes('Géolocalisation')) {
         toast.error("Veuillez autoriser l'accès à votre position")
+      } else if (error.response?.data?.message) {
+        // Afficher le message d'erreur retourné par l'API (ex: trop loin du bureau)
+        toast.error(error.response.data.message)
       }
       // les autres erreurs sont gérées par l'intercepteur API
     } finally {
@@ -83,6 +86,9 @@ export default function CheckIn() {
     } catch (error: any) {
       if (error.message.includes('Géolocalisation')) {
         toast.error("Veuillez autoriser l'accès à votre position")
+      } else if (error.response?.data?.message) {
+        // Afficher le message d'erreur retourné par l'API (ex: mission non autorisée)
+        toast.error(error.response.data.message)
       }
       // autres erreurs gérées par l'intercepteur API
     } finally {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,7 +17,11 @@ api.interceptors.response.use(
   },
   (error) => {
     console.error(`❌ ${error.config?.method?.toUpperCase()} ${error.config?.url} - ${error.response?.status || 'NETWORK_ERROR'}`)
-    console.error('Détails de l\'erreur API:', error)
+    if (error.response?.data?.message) {
+      console.error("Détails de l'erreur API:", error.response.data.message)
+    } else {
+      console.error("Détails de l'erreur API:", error)
+    }
     
     if (error.code === 'ECONNREFUSED' || error.message.includes('Network Error')) {
       toast.error('Impossible de se connecter au serveur. Veuillez vérifier que le backend est démarré.')
@@ -149,8 +153,12 @@ export const attendanceService = {
     try {
       console.log('🏢 Pointage bureau avec coordonnées:', coordinates)
       return await api.post('/attendance/checkin/office', { coordinates })
-    } catch (error) {
-      console.error('Office checkin service error:', error)
+    } catch (error: any) {
+      if (error.response?.data?.message) {
+        console.error('Office checkin service error:', error.response.data.message)
+      } else {
+        console.error('Office checkin service error:', error)
+      }
       throw error
     }
   },
@@ -166,8 +174,12 @@ export const attendanceService = {
       }
       
       return await api.post('/attendance/checkin/mission', data)
-    } catch (error) {
-      console.error('Mission checkin service error:', error)
+    } catch (error: any) {
+      if (error.response?.data?.message) {
+        console.error('Mission checkin service error:', error.response.data.message)
+      } else {
+        console.error('Mission checkin service error:', error)
+      }
       throw error
     }
   },


### PR DESCRIPTION
## Summary
- log more helpful API error details in the interceptor
- show server message in console for office/mission check-in failures

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713da3adfc8332b46e6f9e6b3e82fb