### PR TITLE
Add employee details link

### DIFF
--- a/src/pages/EmployeeManagement.tsx
+++ b/src/pages/EmployeeManagement.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { adminService } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
+import { Link } from 'react-router-dom'
 import { 
   Users, 
   Plus, 
@@ -680,7 +681,12 @@ export default function EmployeeManagement() {
                       </div>
                       <div className="ml-4">
                         <div className="text-sm font-medium text-gray-900">
-                          {employee.prenom} {employee.nom}
+                          <Link
+                            to={`/admin/employees/${employee.id}`}
+                            className="text-blue-600 hover:underline"
+                          >
+                            {employee.prenom} {employee.nom}
+                          </Link>
                         </div>
                         <div className="text-sm text-gray-500">
                           #{employee.employee_number}


### PR DESCRIPTION
## Summary
- enable navigation to an employee's detail page from the employee list

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6873c8fb62408332b1bd8885d76d89dd