### PR TITLE
Fix service merge artifacts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, send_from_directory
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 from flask_sse import sse
@@ -100,7 +100,18 @@ def create_app():
     app.register_blueprint(leave_bp, url_prefix='/api/leave') # Registered Leave blueprint
     app.register_blueprint(webhook_bp, url_prefix='/api/webhooks') # Registered Webhook blueprint
     app.register_blueprint(two_factor_bp, url_prefix='/api/auth/2fa') # Registered 2FA blueprint under /auth path
-    
+
+    # Ensure upload folder exists and expose uploads route
+    upload_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', app.config['UPLOAD_FOLDER']))
+    os.makedirs(upload_folder, exist_ok=True)
+    # Store absolute path back in config for other modules
+    app.config['UPLOAD_FOLDER'] = upload_folder
+
+    @app.route('/uploads/<path:filename>')
+    def uploaded_file(filename):
+        """Serve files from the uploads directory."""
+        return send_from_directory(upload_folder, filename)
+
     # Create database tables
     with app.app_context():
         init_db()

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -26,6 +26,7 @@ from .webhook_subscription import WebhookSubscription
 from .webhook_delivery_log import WebhookDeliveryLog
 from .company_holiday import CompanyHoliday
 from .password_history import PasswordHistory # Added PasswordHistory
+from .subscription_extension_request import SubscriptionExtensionRequest
 
 __all__ = [
     'User',
@@ -50,5 +51,6 @@ __all__ = [
     'WebhookDeliveryLog',
     'CompanyHoliday',
     'PasswordHistory',
-    'Pause'
+    'Pause',
+    'SubscriptionExtensionRequest'
 ]

--- a/backend/models/subscription_extension_request.py
+++ b/backend/models/subscription_extension_request.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from backend.database import db
+
+class SubscriptionExtensionRequest(db.Model):
+    __tablename__ = 'subscription_extension_requests'
+
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey('companies.id'), nullable=False)
+    months = db.Column(db.Integer, nullable=False)
+    reason = db.Column(db.Text, nullable=True)
+    status = db.Column(db.String(20), default='pending', nullable=False)  # pending, approved, rejected
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    processed_at = db.Column(db.DateTime, nullable=True)
+    processed_by = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
+
+    company = db.relationship('Company')
+    processed_by_user = db.relationship('User')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'company_id': self.company_id,
+            'company_name': self.company.name if self.company else None,
+            'months': self.months,
+            'reason': self.reason,
+            'status': self.status,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'processed_at': self.processed_at.isoformat() if self.processed_at else None,
+            'processed_by': self.processed_by,
+        }
+
+    def __repr__(self):
+        return f'<SubscriptionExtensionRequest {self.company_id} +{self.months}m status={self.status}>'

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -2,12 +2,14 @@
 Routes Admin - Gestion des entreprises
 """
 
-from flask import Blueprint, request, jsonify, send_file
+from flask import Blueprint, request, jsonify, send_file, send_from_directory, current_app
 from flask_jwt_extended import jwt_required
 from middleware.auth import require_admin, require_manager_or_above, get_current_user
 from middleware.audit import log_user_action
 from backend.models.user import User
 from backend.models.company import Company
+from backend.models.invoice import Invoice
+from backend.models.subscription_extension_request import SubscriptionExtensionRequest
 from backend.models.office import Office
 from backend.models.department import Department
 from backend.models.service import Service
@@ -23,11 +25,13 @@ from datetime import datetime
 from backend.utils.pdf_utils import build_pdf_document, create_styled_table, get_report_styles, generate_report_title_elements
 from backend.database import db
 import json
-from flask import current_app # Added for FRONTEND_URL
+from werkzeug.utils import secure_filename
+import os
 
 # Stripe utilities
 from backend.services import stripe_service
 from backend.routes.stripe_routes import get_stripe_price_to_plan_mapping
+from backend.services.stripe_service import create_checkout_session
 
 
 admin_bp = Blueprint('admin', __name__)
@@ -172,6 +176,77 @@ def create_company_customer_portal_session():
     except Exception as e:
         current_app.logger.error(f"Error creating customer portal for company {company.id}: {e}")
         return jsonify(message="Erreur interne du serveur lors de la création du portail client."), 500
+
+
+@admin_bp.route('/subscription/extension-request', methods=['POST'])
+@require_admin
+def request_subscription_extension():
+    """Crée une demande de prolongation d'abonnement qui devra être validée par le superadmin."""
+    current_admin = get_current_user()
+    if not current_admin.company_id:
+        return jsonify(message="Aucune entreprise associée"), 400
+
+    data = request.get_json() or {}
+    months = data.get('months', 1)
+    reason = data.get('reason', '')
+
+    if months < 1 or months > 24:
+        return jsonify(message="Le nombre de mois doit être entre 1 et 24."), 400
+
+    extension_req = SubscriptionExtensionRequest(
+        company_id=current_admin.company_id,
+        months=months,
+        reason=reason,
+        status='pending'
+    )
+    db.session.add(extension_req)
+    db.session.commit()
+
+    log_user_action(
+        action='REQUEST_SUBSCRIPTION_EXTENSION',
+        resource_type='SubscriptionExtensionRequest',
+        resource_id=extension_req.id,
+        new_values=extension_req.to_dict(),
+        details={'company_id': current_admin.company_id}
+    )
+
+    return jsonify({'request': extension_req.to_dict()}), 201
+
+
+@admin_bp.route('/company/invoices', methods=['GET'])
+@require_admin
+def list_company_invoices():
+    """Liste les factures de l'entreprise de l'administrateur."""
+    current_user = get_current_user()
+    if not current_user.company_id:
+        return jsonify(message="Aucune entreprise associée"), 400
+    invoices = (
+        Invoice.query.filter_by(company_id=current_user.company_id)
+        .order_by(Invoice.created_at.desc())
+        .all()
+    )
+    return jsonify({'invoices': [inv.to_dict() for inv in invoices]}), 200
+
+
+@admin_bp.route('/invoices/<int:invoice_id>/stripe-session', methods=['POST'])
+@require_admin
+def create_invoice_checkout_session_admin(invoice_id):
+    """Crée une session Stripe pour payer une facture."""
+    current_user = get_current_user()
+    invoice = Invoice.query.get_or_404(invoice_id)
+    if current_user.role != 'superadmin' and invoice.company_id != current_user.company_id:
+        return jsonify(message="Accès non autorisé"), 403
+
+    data = request.get_json() or {}
+    frontend_url = current_app.config.get('FRONTEND_URL', 'http://localhost:5173')
+    success_url = data.get('success_url', f"{frontend_url}/company/billing?status=paid")
+    cancel_url = data.get('cancel_url', f"{frontend_url}/company/billing?status=cancel")
+    try:
+        session = create_checkout_session(invoice, success_url, cancel_url)
+        return jsonify({'session_id': session.id, 'checkout_url': session.url}), 200
+    except Exception as e:
+        print(f"Erreur lors de la création de session Stripe: {e}")
+        return jsonify(message="Erreur interne du serveur"), 500
 
 
 @admin_bp.route('/employees', methods=['GET'])
@@ -1039,7 +1114,29 @@ def update_company_settings():
         
         for field in updatable_fields:
             if field in data:
-                setattr(company, field, data[field])
+                value = data[field]
+                if field == 'work_start_time' and isinstance(value, str):
+                    try:
+                        if len(value.split(':')) == 3:
+                            value = datetime.strptime(value, '%H:%M:%S').time()
+                        else:
+                            value = datetime.strptime(value, '%H:%M').time()
+                    except ValueError:
+                        return jsonify(message="Format d'heure invalide"), 400
+
+                if field in ['office_latitude', 'office_longitude'] and value is not None:
+                    try:
+                        value = float(value)
+                    except ValueError:
+                        return jsonify(message="Valeur de latitude/longitude invalide"), 400
+
+                if field in ['office_radius', 'late_threshold'] and value is not None:
+                    try:
+                        value = int(value)
+                    except ValueError:
+                        return jsonify(message="Valeur numérique invalide"), 400
+
+                setattr(company, field, value)
         
         # Logger l'action
         log_user_action(
@@ -1069,6 +1166,57 @@ def update_company_settings():
         
     except Exception as e:
         print(f"Erreur lors de la mise à jour des paramètres: {e}")
+        db.session.rollback()
+        return jsonify(message="Erreur interne du serveur"), 500
+
+
+@admin_bp.route('/company/logo', methods=['POST'])
+@require_admin
+def upload_company_logo():
+    """Upload a new logo for the company and update the URL."""
+    try:
+        current_user = get_current_user()
+        if not current_user.company_id:
+            return jsonify(message="Aucune entreprise associée à cet utilisateur"), 400
+
+        if 'logo' not in request.files:
+            return jsonify(message="Fichier logo manquant"), 400
+
+        file = request.files['logo']
+        if file.filename == '':
+            return jsonify(message="Nom de fichier vide"), 400
+
+        allowed_ext = {'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'}
+        if '.' not in file.filename or file.filename.rsplit('.', 1)[1].lower() not in allowed_ext:
+            return jsonify(message="Format de fichier non supporté"), 400
+
+        filename = secure_filename(file.filename)
+        logo_folder = os.path.join(current_app.config['UPLOAD_FOLDER'], 'company_logos')
+        os.makedirs(logo_folder, exist_ok=True)
+        filename = f"{current_user.company_id}_{filename}"
+        file_path = os.path.join(logo_folder, filename)
+        file.save(file_path)
+
+        url = f"/uploads/company_logos/{filename}"
+
+        company = Company.query.get_or_404(current_user.company_id)
+        old_values = company.to_dict()
+        company.logo_url = url
+
+        log_user_action(
+            action='UPDATE_COMPANY_LOGO',
+            resource_type='Company',
+            resource_id=company.id,
+            old_values=old_values,
+            new_values=company.to_dict(),
+        )
+
+        db.session.commit()
+
+        return jsonify({'logo_url': url, 'message': 'Logo mis à jour'}), 200
+
+    except Exception as e:
+        print(f"Erreur lors du téléversement du logo: {e}")
         db.session.rollback()
         return jsonify(message="Erreur interne du serveur"), 500
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import AdvancedFeatures from './pages/AdvancedFeatures'
 import RoleManagementPage from './pages/RoleManagementPage'
 import BillingManagement from './pages/BillingManagement'
 import WebhookManagementPage from './pages/WebhookManagementPage'
+import ExtensionRequestsPage from './pages/ExtensionRequests'
 import Missions from './pages/Missions'
 import RequestLeavePage from './pages/RequestLeavePage';
 import MyLeaveHistoryPage from './pages/MyLeaveHistoryPage'; // Added MyLeaveHistoryPage
@@ -84,6 +85,13 @@ function App() {
             <ProtectedRoute requiredRole="superadmin">
               <Layout>
                 <BillingManagement />
+              </Layout>
+            </ProtectedRoute>
+          } />
+          <Route path="/superadmin/extension-requests" element={
+            <ProtectedRoute requiredRole="superadmin">
+              <Layout>
+                <ExtensionRequestsPage />
               </Layout>
             </ProtectedRoute>
           } />

--- a/src/components/CompanySettings.tsx
+++ b/src/components/CompanySettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 import { adminService } from '../services/api'
 import {
@@ -32,10 +32,19 @@ interface SubscriptionData {
   billing_portal_enabled: boolean;
 }
 
+interface Invoice {
+  id: number;
+  amount: number;
+  months: number;
+  status: string;
+  due_date?: string;
+  paid_date?: string;
+}
+
 export default function CompanySettings() {
   const navigate = useNavigate(); // For clearing query params
   const [searchParams] = useSearchParams();
-  const { isAdmin } = useAuth()
+  const { isAdmin, fetchUser } = useAuth()
   const [settings, setSettings] = useState({
     office_latitude: 48.8566,
     office_longitude: 2.3522,
@@ -51,6 +60,10 @@ export default function CompanySettings() {
   const [subscriptionLoading, setSubscriptionLoading] = useState(true);
   const [subscriptionData, setSubscriptionData] = useState<SubscriptionData | null>(null);
   const [actionLoading, setActionLoading] = useState(false); // For button actions like subscribe/portal
+  const [extensionMonths, setExtensionMonths] = useState(1);
+  const [extensionReason, setExtensionReason] = useState('');
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [invoicesLoading, setInvoicesLoading] = useState(true);
 
   // State for Leave Policy
   const [leavePolicyLoading, setLeavePolicyLoading] = useState(true);
@@ -60,14 +73,28 @@ export default function CompanySettings() {
   const [newHoliday, setNewHoliday] = useState({ date: '', name: '' });
   const [leavePolicySaving, setLeavePolicySaving] = useState(false);
 
-  // Charger les paramètres de l'entreprise, l'abonnement, et la politique de congés
+  // Helper to load invoices
+  const loadInvoices = async () => {
+    setInvoicesLoading(true)
+    try {
+      const resp = await adminService.getCompanyInvoices()
+      setInvoices(resp.data.invoices)
+    } catch (error) {
+      console.error('Erreur chargement factures:', error)
+    } finally {
+      setInvoicesLoading(false)
+    }
+  }
+
+  // Charger les paramètres de l'entreprise, l'abonnement et la politique de congés
   useEffect(() => {
     if (isAdmin) {
-      loadCompanySettings();
-      loadSubscriptionData();
-      loadLeavePolicy();
+      loadCompanySettings()
+      loadSubscriptionData()
+      loadLeavePolicy()
+      loadInvoices()
     }
-  }, [isAdmin]);
+  }, [isAdmin])
 
   // Handle Stripe redirect
   useEffect(() => {
@@ -108,11 +135,30 @@ export default function CompanySettings() {
       // Appel API pour sauvegarder les paramètres
       await adminService.updateCompanySettings(settings)
       toast.success('Paramètres sauvegardés avec succès!')
+      if (fetchUser) {
+        await fetchUser()
+      }
     } catch (error) {
       console.error('Erreur lors de la sauvegarde:', error)
       toast.error('Erreur lors de la sauvegarde')
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleLogoFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      try {
+        const resp = await adminService.uploadCompanyLogo(e.target.files[0])
+        setSettings(prev => ({ ...prev, logo_url: resp.data.logo_url }))
+        toast.success('Logo mis à jour')
+        if (fetchUser) {
+          await fetchUser()
+        }
+      } catch (error) {
+        console.error('Erreur upload logo:', error)
+        toast.error('Erreur lors du téléversement du logo')
+      }
     }
   }
 
@@ -157,6 +203,38 @@ export default function CompanySettings() {
       }
     } catch (error) {
       console.error('Erreur création portail client:', error);
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  const handleExtensionRequest = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setActionLoading(true);
+    try {
+      await adminService.requestSubscriptionExtension(extensionMonths, extensionReason);
+      toast.success('Demande de prolongation envoyée');
+      setExtensionReason('');
+      setExtensionMonths(1);
+    } catch (error) {
+      console.error('Erreur demande prolongation:', error);
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+
+  const handlePayInvoice = async (invoiceId: number) => {
+    setActionLoading(true);
+    try {
+      const resp = await adminService.createInvoiceCheckoutSession(invoiceId);
+      if (resp.data.checkout_url) {
+        window.location.href = resp.data.checkout_url;
+      } else {
+        toast.error("Impossible d'ouvrir la page de paiement");
+      }
+    } catch (error) {
+      console.error('Erreur création session de paiement:', error);
     } finally {
       setActionLoading(false);
     }
@@ -397,6 +475,20 @@ export default function CompanySettings() {
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
+                Téléverser un logo
+              </label>
+              <input
+                type="file"
+                accept="image/*"
+                onChange={handleLogoFileChange}
+                className="input-field"
+              />
+              {settings.logo_url && (
+                <img src={settings.logo_url} alt="Logo" className="h-16 mt-2 object-contain" />
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
                 Couleur principale
               </label>
               <input
@@ -567,6 +659,61 @@ export default function CompanySettings() {
                 </div>
               ) : (
                  <p className="text-gray-500 text-sm">Aucun autre plan n'est disponible pour le moment.</p>
+              )}
+            </div>
+
+            <div className="card mt-6">
+              <h3 className="text-lg font-semibold text-gray-800 mb-3">Prolonger l'abonnement</h3>
+              <form onSubmit={handleExtensionRequest} className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Nombre de mois</label>
+                  <input type="number" min={1} max={24} value={extensionMonths} onChange={(e) => setExtensionMonths(parseInt(e.target.value))} className="input-field w-32" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Raison (optionnel)</label>
+                  <textarea value={extensionReason} onChange={(e) => setExtensionReason(e.target.value)} className="input-field" rows={2} />
+                </div>
+                <button type="submit" disabled={actionLoading} className="btn-primary">
+                  {actionLoading ? 'Envoi...' : 'Envoyer la demande'}
+                </button>
+              </form>
+            </div>
+
+            <div className="card mt-6">
+              <h3 className="text-lg font-semibold text-gray-800 mb-3">Vos factures</h3>
+              {invoicesLoading ? (
+                <p className="text-sm text-gray-500">Chargement...</p>
+              ) : invoices.length > 0 ? (
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr>
+                      <th className="px-2 py-1 text-left">ID</th>
+                      <th className="px-2 py-1 text-left">Montant</th>
+                      <th className="px-2 py-1 text-left">Mois</th>
+                      <th className="px-2 py-1 text-left">Statut</th>
+                      <th className="px-2 py-1"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {invoices.map((inv) => (
+                      <tr key={inv.id} className="border-t">
+                        <td className="px-2 py-1">{inv.id}</td>
+                        <td className="px-2 py-1">{inv.amount}€</td>
+                        <td className="px-2 py-1">{inv.months}</td>
+                        <td className="px-2 py-1 capitalize">{inv.status}</td>
+                        <td className="px-2 py-1">
+                          {inv.status !== 'paid' && (
+                            <button onClick={() => handlePayInvoice(inv.id)} className="btn-primary btn-xs">
+                              Payer
+                            </button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              ) : (
+                <p className="text-sm text-gray-500">Aucune facture disponible.</p>
               )}
             </div>
           </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -58,6 +58,7 @@ export default function Layout({ children }: LayoutProps) {
       nav.push(
         { name: 'Dashboard SuperAdmin', href: '/superadmin', icon: Crown, priority: false, permission: null },
         { name: 'Gestion Entreprises', href: '/superadmin/companies', icon: Building, priority: false, permission: null },
+        { name: 'Demandes Abonnement', href: '/superadmin/extension-requests', icon: Clock, priority: false, permission: null },
         { name: 'Configuration Système', href: '/settings', icon: Settings, priority: false, permission: null },
         { name: 'Rôles & Privilèges', href: '/roles', icon: Shield, priority: false, permission: null },
         { name: 'Analytics Globales', href: '/reports', icon: BarChart3, priority: false, permission: null }

--- a/src/components/SubscriptionExtensionRequests.tsx
+++ b/src/components/SubscriptionExtensionRequests.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { usePermissions } from '../hooks/usePermissions'
+import { useApi, useAsyncAction } from '../hooks/useApi'
+import { superAdminService } from '../services/api'
+import LoadingSpinner from './shared/LoadingSpinner'
+import { Check, X } from 'lucide-react'
+
+interface ExtensionRequest {
+  id: number
+  company_id: number
+  company_name?: string
+  months: number
+  reason?: string
+  status: string
+  created_at: string
+}
+
+export default function SubscriptionExtensionRequests() {
+  const { permissions } = usePermissions()
+  const { data, loading, refetch } = useApi(() => superAdminService.listSubscriptionExtensionRequests(), [])
+  const { loading: actionLoading, execute } = useAsyncAction()
+
+  if (!permissions.canGlobalManagement) {
+    return (
+      <div className="card text-center">
+        <p className="text-gray-600">Accès SuperAdmin requis</p>
+      </div>
+    )
+  }
+
+  const requests: ExtensionRequest[] = data?.requests || []
+
+  const approve = (id: number) =>
+    execute(async () => {
+      await superAdminService.approveSubscriptionExtensionRequest(id)
+      refetch()
+    }, 'Demande approuvée')
+
+  const reject = (id: number) =>
+    execute(async () => {
+      await superAdminService.rejectSubscriptionExtensionRequest(id)
+      refetch()
+    }, 'Demande rejetée')
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Demandes de prolongation d\'abonnement</h1>
+      {loading ? (
+        <LoadingSpinner text="Chargement des demandes..." />
+      ) : (
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr>
+              <th className="px-4 py-2 text-left">Entreprise</th>
+              <th className="px-4 py-2 text-left">Mois</th>
+              <th className="px-4 py-2 text-left">Raison</th>
+              <th className="px-4 py-2 text-left">Statut</th>
+              <th className="px-4 py-2 text-left">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {requests.map((req) => (
+              <tr key={req.id} className="border-t">
+                <td className="px-4 py-2">{req.company_name || `ID ${req.company_id}`}</td>
+                <td className="px-4 py-2">{req.months}</td>
+                <td className="px-4 py-2">{req.reason || '-'}</td>
+                <td className="px-4 py-2 capitalize">{req.status}</td>
+                <td className="px-4 py-2 space-x-2">
+                  {req.status === 'pending' && (
+                    <>
+                      <button
+                        onClick={() => approve(req.id)}
+                        disabled={actionLoading}
+                        className="btn-primary btn-xs"
+                      >
+                        <Check className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => reject(req.id)}
+                        disabled={actionLoading}
+                        className="btn-danger btn-xs"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -19,6 +19,7 @@ interface AuthContextType {
   user: User | null
   login: (email: string, password: string) => Promise<void>
   logout: () => void
+  fetchUser?: () => Promise<void>
   loading: boolean
   isSuperAdmin: boolean
   isAdminRH: boolean
@@ -149,6 +150,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     console.log('Déconnexion terminée')
   }
 
+  // Rafraîchir les informations utilisateur depuis l'API
+  const fetchUser = async () => {
+    try {
+      const resp = await authService.me()
+      setUser(resp.data.user)
+    } catch (error) {
+      console.error('Erreur lors du rafraîchissement utilisateur:', error)
+    }
+  }
+
   // Définition des rôles avec le nouveau système
   const isSuperAdmin = user?.role === 'superadmin'
   const isAdminRH = user?.role === 'admin_rh'
@@ -165,6 +176,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     user,
     login,
     logout,
+    fetchUser,
     loading,
     isSuperAdmin,
     isAdminRH,

--- a/src/pages/ExtensionRequests.tsx
+++ b/src/pages/ExtensionRequests.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import SubscriptionExtensionRequests from '../components/SubscriptionExtensionRequests'
+
+export default function ExtensionRequestsPage() {
+  return <SubscriptionExtensionRequests />
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,25 @@
 import React from 'react'
+import CompanySettings from '../components/CompanySettings'
 import EnhancedSettings from '../components/EnhancedSettings'
+import { usePermissions } from '../hooks/usePermissions'
 
 export default function Settings() {
-  return <EnhancedSettings />
+  const { permissions } = usePermissions()
+
+  if (permissions.canGlobalManagement) {
+    return <EnhancedSettings />
+  }
+
+  if (permissions.canManageCompanySettings) {
+    return <CompanySettings />
+  }
+
+  return (
+    <div className="card text-center">
+      <h3 className="text-lg font-medium text-gray-900 mb-2">Accès restreint</h3>
+      <p className="text-gray-600">
+        Vous n'avez pas les permissions nécessaires pour accéder aux paramètres.
+      </p>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- clean up admin vs superadmin APIs after merge
- restore invoice helpers under `adminService`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68703933a798833283b1e11833e90f33