### PR TITLE
feat: enforce geolocation accuracy for office check-ins

### DIFF
--- a/backend/routes/attendance_routes.py
+++ b/backend/routes/attendance_routes.py
@@ -30,9 +30,20 @@ def office_checkin():
         
         data = request.get_json()
         coordinates = data.get('coordinates', {})
-        
+
         if not coordinates.get('latitude') or not coordinates.get('longitude'):
             return jsonify(message="Coordonnées GPS requises"), 400
+        if coordinates.get('accuracy') is None:
+            return jsonify(message="Précision GPS requise"), 400
+
+        max_accuracy = current_app.config.get('GEOLOCATION_MAX_ACCURACY', 100)
+        if coordinates['accuracy'] > max_accuracy:
+            return jsonify(
+                message=(
+                    f"Précision de localisation insuffisante ({int(coordinates['accuracy'])}m). "
+                    f"Maximum autorisé: {max_accuracy}m"
+                )
+            ), 400
         
         # Vérifier si l'utilisateur a déjà pointé aujourd'hui
         today = date.today()

--- a/mobile/src/screens/CheckInScreen.tsx
+++ b/mobile/src/screens/CheckInScreen.tsx
@@ -17,7 +17,7 @@ export default function CheckInScreen({ onDone }: { onDone: () => void }) {
         return;
       }
       const loc = await Location.getCurrentPositionAsync({});
-      await checkInOffice({ latitude: loc.coords.latitude, longitude: loc.coords.longitude });
+      await checkInOffice({ latitude: loc.coords.latitude, longitude: loc.coords.longitude, accuracy: loc.coords.accuracy });
       setMessage('Pointage effectué');
     } catch (e) {
       console.error(e);

--- a/mobile/src/services/attendanceService.ts
+++ b/mobile/src/services/attendanceService.ts
@@ -1,6 +1,6 @@
 import apiClient from '../api/client';
 
-export const checkInOffice = async (coords: { latitude: number; longitude: number }) => {
+export const checkInOffice = async (coords: { latitude: number; longitude: number; accuracy: number }) => {
   const payload = { coordinates: coords };
   return apiClient.post('/attendance/checkin/office', payload);
 };

--- a/src/components/CheckIn.tsx
+++ b/src/components/CheckIn.tsx
@@ -7,7 +7,7 @@ export default function CheckIn() {
   const [activeTab, setActiveTab] = useState<'office' | 'mission'>('office')
   const [loading, setLoading] = useState(false)
   const [missionOrderNumber, setMissionOrderNumber] = useState('')
-  const [currentLocation, setCurrentLocation] = useState<{latitude: number, longitude: number} | null>(null)
+  const [currentLocation, setCurrentLocation] = useState<{latitude: number, longitude: number, accuracy: number} | null>(null)
   const [locationLoading, setLocationLoading] = useState(false)
 
   // Obtenir la position actuelle au chargement du composant
@@ -26,7 +26,8 @@ export default function CheckIn() {
       (position) => {
         const newLocation = {
           latitude: position.coords.latitude,
-          longitude: position.coords.longitude
+          longitude: position.coords.longitude,
+          accuracy: position.coords.accuracy
         }
         
         // Validation des coordonnées

--- a/src/components/attendance/CheckInMethods.tsx
+++ b/src/components/attendance/CheckInMethods.tsx
@@ -9,7 +9,7 @@ export default function CheckInMethods() {
   const [activeMethod, setActiveMethod] = useState<'geo' | 'qr' | 'nfc' | 'offline' | null>(null)
   const [loading, setLoading] = useState(false)
   
-  const handleGeoCheckIn = async (coordinates: {latitude: number, longitude: number}) => {
+  const handleGeoCheckIn = async (coordinates: {latitude: number, longitude: number, accuracy: number}) => {
     setLoading(true)
     try {
       const { data } = await attendanceService.checkInOffice(coordinates)

--- a/src/components/attendance/GeoCheck.tsx
+++ b/src/components/attendance/GeoCheck.tsx
@@ -3,13 +3,13 @@ import { MapPin, Loader } from 'lucide-react'
 import toast from 'react-hot-toast'
 
 interface Props {
-  onCheckIn: (coordinates: {latitude: number, longitude: number}) => void
+  onCheckIn: (coordinates: {latitude: number, longitude: number, accuracy: number}) => void
   onCancel: () => void
   loading: boolean
 }
 
 export default function GeoCheck({ onCheckIn, onCancel, loading }: Props) {
-  const [coordinates, setCoordinates] = useState<{latitude: number, longitude: number} | null>(null)
+  const [coordinates, setCoordinates] = useState<{latitude: number, longitude: number, accuracy: number} | null>(null)
   const [geoError, setGeoError] = useState<string | null>(null)
   const [loadingLocation, setLoadingLocation] = useState(true)
 
@@ -25,7 +25,8 @@ export default function GeoCheck({ onCheckIn, onCancel, loading }: Props) {
         (position) => {
           setCoordinates({
             latitude: position.coords.latitude,
-            longitude: position.coords.longitude
+            longitude: position.coords.longitude,
+            accuracy: position.coords.accuracy
           })
           setLoadingLocation(false)
         },

--- a/src/pages/CheckIn.test.tsx
+++ b/src/pages/CheckIn.test.tsx
@@ -18,7 +18,7 @@ test('mission checkin calls service', async () => {
   const { attendanceService } = require('../services/api');
   // mock geolocation
   const mockGetCurrentPosition = jest.fn().mockImplementation((success) => {
-    success({ coords: { latitude: 1, longitude: 2 } });
+    success({ coords: { latitude: 1, longitude: 2, accuracy: 5 } });
   });
   // @ts-ignore
   global.navigator.geolocation = { getCurrentPosition: mockGetCurrentPosition };
@@ -27,5 +27,5 @@ test('mission checkin calls service', async () => {
   fireEvent.click(screen.getByText('Pointage Mission'));
   fireEvent.change(screen.getByLabelText("Numéro d'ordre de mission"), { target: { value: 'M1' } });
   fireEvent.click(screen.getByText('Pointer en Mission'));
-  await waitFor(() => expect(attendanceService.checkInMission).toHaveBeenCalledWith('M1', { latitude: 1, longitude: 2 }));
+  await waitFor(() => expect(attendanceService.checkInMission).toHaveBeenCalledWith('M1', { latitude: 1, longitude: 2, accuracy: 5 }));
 });

--- a/src/pages/CheckIn.tsx
+++ b/src/pages/CheckIn.tsx
@@ -33,7 +33,8 @@ export default function CheckIn() {
       const position = await getCurrentLocation()
       const coordinates = {
         latitude: position.coords.latitude,
-        longitude: position.coords.longitude
+        longitude: position.coords.longitude,
+        accuracy: position.coords.accuracy
       }
 
       const { data } = await attendanceService.checkInOffice(coordinates)
@@ -68,7 +69,8 @@ export default function CheckIn() {
       const position = await getCurrentLocation()
       const coordinates = {
         latitude: position.coords.latitude,
-        longitude: position.coords.longitude
+        longitude: position.coords.longitude,
+        accuracy: position.coords.accuracy
       }
 
       const { data } = await attendanceService.checkInMission(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -152,7 +152,7 @@ export const authService = {
 }
 
 export const attendanceService = {
-  checkInOffice: async (coordinates: { latitude: number; longitude: number; qrCode?: string }) => {
+  checkInOffice: async (coordinates: { latitude: number; longitude: number; accuracy?: number; qrCode?: string }) => {
     try {
       // Ne pas logger les coordonnées en production pour des raisons de confidentialité
       // console.log('🏢 Pointage bureau avec coordonnées:', coordinates)


### PR DESCRIPTION
## Summary
- include GPS accuracy when performing geolocation check-ins
- forward accuracy to API service and reject low-precision coordinates server-side
- update related components, mobile client, and tests to use accuracy

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --no-save jest-environment-jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest-environment-jsdom)*
- `pytest` *(fails: Table 'users' is already defined for this MetaData instance)*

------
https://chatgpt.com/codex/tasks/task_e_688df73fd2b48332b86c66f197a7c3cc