### PR TITLE
feat(mobile): add tab navigation with profile and settings

### DIFF
--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { useAuth } from '../contexts/AuthContext';
 
 import LoginScreen from '../screens/LoginScreen';
 import HomeScreen from '../screens/HomeScreen';
+import ProfileScreen from '../screens/ProfileScreen';
+import SettingsScreen from '../screens/SettingsScreen';
 
 // Define types for your navigation stacks if using TypeScript
 export type AuthStackParamList = {
@@ -12,15 +15,14 @@ export type AuthStackParamList = {
   // Signup: undefined; // If you have a signup screen
 };
 
-export type MainStackParamList = {
+export type MainTabParamList = {
   Home: undefined;
-  // Profile: undefined;
-  // Settings: undefined;
-  // ... other screens
+  Profile: undefined;
+  Settings: undefined;
 };
 
 const AuthStack = createNativeStackNavigator<AuthStackParamList>();
-const MainStack = createNativeStackNavigator<MainStackParamList>();
+const Tab = createBottomTabNavigator<MainTabParamList>();
 
 // Basic SplashScreen placeholder while auth state loads
 const SplashScreen = () => <></>;
@@ -37,12 +39,12 @@ const AppNavigator = () => {
   return (
     <NavigationContainer>
       {user ? (
-        // User is signed in, show main app stack
-        <MainStack.Navigator>
-          <MainStack.Screen name="Home" component={HomeScreen} options={{ title: 'Dashboard' }}/>
-          {/* Add other main app screens here */}
-          {/* e.g., <MainStack.Screen name="Profile" component={ProfileScreen} /> */}
-        </MainStack.Navigator>
+        // User is signed in, show main app tabs
+        <Tab.Navigator>
+          <Tab.Screen name="Home" component={HomeScreen} options={{ title: 'Accueil' }} />
+          <Tab.Screen name="Profile" component={ProfileScreen} options={{ title: 'Profil' }} />
+          <Tab.Screen name="Settings" component={SettingsScreen} options={{ title: 'Paramètres' }} />
+        </Tab.Navigator>
       ) : (
         // No user signed in, show auth stack
         <AuthStack.Navigator screenOptions={{ headerShown: false }}>

--- a/mobile/src/screens/ProfileScreen.tsx
+++ b/mobile/src/screens/ProfileScreen.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ProfileScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Profil</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 16 },
+});

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Paramètres</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 16 },
+});


### PR DESCRIPTION
## Summary
- replace main stack navigator with bottom tab navigation
- add placeholder Profile and Settings screens

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: invalid option '--ext')*
- `npx tsc --noEmit mobile/src/navigation/AppNavigator.tsx mobile/src/screens/ProfileScreen.tsx mobile/src/screens/SettingsScreen.tsx` *(fails: cannot find module @react-navigation/...)*

------
https://chatgpt.com/codex/tasks/task_e_688fe887ed108332946b0d754df764c6