### PR TITLE
feat: add dark mode toggle and tenant theming

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-full bg-gray-200 dark:bg-gray-700"
+      aria-label="Toggle theme"
+    >
+      {theme === 'dark' ? '🌙' : '☀️'}
+    </button>
+  );
+}

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import ThemeToggle from '../ThemeToggle';
 
 interface DefaultLayoutProps {
   children: ReactNode;
@@ -6,7 +7,7 @@ interface DefaultLayoutProps {
 
 export default function DefaultLayout({ children }: DefaultLayoutProps) {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <div className="flex min-h-screen">
         {/* Sidebar would go here in a real implementation */}
         <div className="hidden md:block md:w-64 bg-primary-900 text-white p-4">
@@ -20,8 +21,8 @@ export default function DefaultLayout({ children }: DefaultLayoutProps) {
         {/* Main content */}
         <div className="flex-1">
           {/* Header would go here in a real implementation */}
-          <header className="bg-white border-b h-16 flex items-center px-6 shadow-sm">
-            {/* Header content */}
+          <header className="bg-background border-b border-border h-16 flex items-center justify-end px-6 shadow-sm">
+            <ThemeToggle />
           </header>
           
           {/* Page content */}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,82 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+type Density = 'comfortable' | 'compact';
+
+interface TenantColors {
+  primary?: Partial<Record<'50' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900', string>>;
+  background?: string;
+}
+
+interface ThemeContextValue {
+  theme: Theme;
+  density: Density;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+  setDensity: (density: Density) => void;
+  setTenantColors: (colors: TenantColors) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem('theme') as Theme) || 'light');
+  const [density, setDensityState] = useState<Density>(() => (localStorage.getItem('density') as Density) || 'comfortable');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') root.classList.add('dark');
+    else root.classList.remove('dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.dataset.density = density;
+    localStorage.setItem('density', density);
+  }, [density]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const storedPrimary = localStorage.getItem('tenant-primary');
+    const storedBackground = localStorage.getItem('tenant-background');
+    if (storedBackground) {
+      root.style.setProperty('--color-background', storedBackground);
+    }
+    if (storedPrimary) {
+      const palette = JSON.parse(storedPrimary);
+      Object.entries(palette).forEach(([shade, value]) => {
+        root.style.setProperty(`--color-primary-${shade}`, value as string);
+      });
+    }
+  }, []);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  const setDensity = (d: Density) => setDensityState(d);
+
+  const setTenantColors = (colors: TenantColors) => {
+    const root = document.documentElement;
+    if (colors.background) {
+      root.style.setProperty('--color-background', colors.background);
+      localStorage.setItem('tenant-background', colors.background);
+    }
+    if (colors.primary) {
+      Object.entries(colors.primary).forEach(([shade, value]) => {
+        root.style.setProperty(`--color-primary-${shade}`, value);
+      });
+      localStorage.setItem('tenant-primary', JSON.stringify(colors.primary));
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, density, setTheme, toggleTheme, setDensity, setTenantColors }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within a ThemeProvider');
+  return ctx;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,26 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --color-primary-50: #eff6ff;
+    --color-primary-100: #dbeafe;
+    --color-primary-200: #bfdbfe;
+    --color-primary-300: #93c5fd;
+    --color-primary-400: #60a5fa;
+    --color-primary-500: #3b82f6;
+    --color-primary-600: #2563eb;
+    --color-primary-700: #1d4ed8;
+    --color-primary-800: #1e40af;
+    --color-primary-900: #1e3a8a;
+    --color-background: #f9fafb;
+    --color-foreground: #111827;
+  }
+
+  .dark {
+    --color-background: #111827;
+    --color-foreground: #f9fafb;
+  }
+
   * {
     @apply border-border;
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,14 +2,17 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import { I18nProvider } from './contexts/I18nContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 import './index.css'
 import { Toaster } from 'react-hot-toast'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <I18nProvider>
-      <App />
-    </I18nProvider>
+    <ThemeProvider>
+      <I18nProvider>
+        <App />
+      </I18nProvider>
+    </ThemeProvider>
     <Toaster
       position="top-right"
       toastOptions={{

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -8,25 +9,53 @@ export default {
     extend: {
       colors: {
         border: '#e5e7eb',
-        background: '#f9fafb',
-        foreground: '#111827',
+        background: 'var(--color-background, #f9fafb)',
+        foreground: 'var(--color-foreground, #111827)',
         primary: {
-          50: '#eff6ff',
-          100: '#dbeafe',
-          200: '#bfdbfe',
-          300: '#93c5fd',
-          400: '#60a5fa',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          800: '#1e40af',
-          900: '#1e3a8a',
+          50: 'var(--color-primary-50, #eff6ff)',
+          100: 'var(--color-primary-100, #dbeafe)',
+          200: 'var(--color-primary-200, #bfdbfe)',
+          300: 'var(--color-primary-300, #93c5fd)',
+          400: 'var(--color-primary-400, #60a5fa)',
+          500: 'var(--color-primary-500, #3b82f6)',
+          600: 'var(--color-primary-600, #2563eb)',
+          700: 'var(--color-primary-700, #1d4ed8)',
+          800: 'var(--color-primary-800, #1e40af)',
+          900: 'var(--color-primary-900, #1e3a8a)',
+        },
+        accent: {
+          50: '#ecfdf5',
+          100: '#d1fae5',
+          200: '#a7f3d0',
+          300: '#6ee7b7',
+          400: '#34d399',
+          500: '#10b981',
+          600: '#059669',
+          700: '#047857',
+          800: '#065f46',
+          900: '#064e3b',
         },
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
       },
+      fontSize: {
+        h1: ['2.25rem', { lineHeight: '2.5rem', fontWeight: '700' }],
+        h2: ['1.875rem', { lineHeight: '2.25rem', fontWeight: '600' }],
+        h3: ['1.5rem', { lineHeight: '2rem', fontWeight: '600' }],
+        h4: ['1.25rem', { lineHeight: '1.75rem', fontWeight: '500' }],
+        subtitle: ['1rem', { lineHeight: '1.5rem', fontWeight: '500' }],
+        caption: ['0.75rem', { lineHeight: '1rem' }],
+      },
+      spacing: {
+        13: '3.25rem',
+        15: '3.75rem',
+        18: '4.5rem',
+        22: '5.5rem',
+        26: '6.5rem',
+      },
     },
   },
   plugins: [],
 }
+


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode and CSS-variable color tokens for per-tenant customization
- introduce ThemeContext with persistent theme & density preferences
- add header toggle to switch light/dark modes

## Testing
- `npm install --legacy-peer-deps --silent` *(hangs: process did not complete)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ef4f9288332afa9594f4bd53924