### PR TITLE
feat: add dark mode toggle and tenant theming

### DIFF
--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -145,8 +145,8 @@ const NotificationCenter = () => {
   return (
     <div className="relative">
       {/* Bouton de notification */}
-      <button 
-        className="relative p-2 rounded-full hover:bg-gray-100 focus:outline-none"
+      <button
+        className="relative p-2 rounded-full hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500"
         onClick={toggleDropdown}
         aria-label="Notifications"
       >
@@ -160,16 +160,19 @@ const NotificationCenter = () => {
       
       {/* Dropdown des notifications */}
       {showDropdown && (
-        <div 
+        <div
           ref={dropdownRef}
           className="absolute right-0 mt-2 bg-white rounded-lg shadow-lg w-80 max-h-96 overflow-hidden z-50"
+          role="region"
+          aria-live="polite"
+          aria-label="Notifications"
         >
           {/* Entête du dropdown */}
           <div className="flex items-center justify-between p-3 border-b">
             <h3 className="font-semibold">Notifications</h3>
             {unread > 0 && (
-              <button 
-                className="text-blue-600 text-sm hover:text-blue-800"
+              <button
+                className="text-blue-600 text-sm hover:text-blue-800 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded"
                 onClick={markAllAsRead}
               >
                 Marquer tout comme lu
@@ -190,12 +193,11 @@ const NotificationCenter = () => {
             ) : (
               <ul>
                 {notifications.map((notification) => (
-                  <li 
-                    key={notification.id} 
-                    className={`p-3 border-b hover:bg-gray-50 cursor-pointer ${!notification.read ? 'bg-blue-50' : ''}`}
-                    onClick={() => markAsRead(notification.id)}
-                  >
-                    <div className="flex items-start">
+                  <li key={notification.id} className={!notification.read ? 'bg-blue-50' : ''}>
+                    <button
+                      className="w-full text-left p-3 border-b hover:bg-gray-50 flex items-start focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500"
+                      onClick={() => markAsRead(notification.id)}
+                    >
                       <div className="mr-3 mt-1">
                         {getNotificationIcon(notification.type)}
                       </div>
@@ -204,7 +206,7 @@ const NotificationCenter = () => {
                         <p className="text-sm text-gray-600 mt-1">{notification.message}</p>
                         <p className="text-xs text-gray-500 mt-1">{formatRelativeTime(notification.created_at)}</p>
                       </div>
-                    </div>
+                    </button>
                   </li>
                 ))}
               </ul>
@@ -214,8 +216,8 @@ const NotificationCenter = () => {
           {/* Pied du dropdown */}
           {notifications.length > 0 && (
             <div className="p-2 text-center border-t">
-              <button 
-                className="text-blue-600 hover:text-blue-800 text-sm"
+              <button
+                className="text-blue-600 hover:text-blue-800 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded"
                 onClick={() => {
                   setShowDropdown(false);
                   navigate('/notifications/history');

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Sun, Moon } from 'lucide-react';
+import { useTheme } from '../contexts/ThemeContext';
+import Button from './ui/button';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      onClick={toggleTheme}
+      color="secondary"
+      size="sm"
+      aria-label="Toggle theme"
+      icon={theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    />
+  );
+}

--- a/src/components/charts/AttendanceCharts.tsx
+++ b/src/components/charts/AttendanceCharts.tsx
@@ -1,6 +1,17 @@
 import React from 'react';
-// Importez Recharts après l'avoir installé
-// import { BarChart, Bar, PieChart, Pie, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Cell } from 'recharts';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis
+} from 'recharts';
 
 interface AttendanceStats {
   totalRecords: number;
@@ -38,39 +49,27 @@ export const AttendanceOverviewChart: React.FC<{ stats: AttendanceStats }> = ({ 
     { name: 'Absences', value: stats.totalAbsences, color: '#f87171' }
   ];
 
-  // Simuler des données temporelles (à remplacer par des données réelles si disponibles)
-  const renderPieChart = () => {
-    // Si vous utilisez Recharts, décommentez ce code
-    /* return (
-      <ResponsiveContainer width="100%" height={300}>
-        <PieChart>
-          <Pie
-            data={statusData}
-            cx="50%"
-            cy="50%"
-            labelLine={false}
-            outerRadius={100}
-            fill="#8884d8"
-            dataKey="value"
-            label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-          >
-            {statusData.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={entry.color} />
-            ))}
-          </Pie>
-          <Tooltip formatter={(value) => [value, 'Nombre']} />
-          <Legend />
-        </PieChart>
-      </ResponsiveContainer>
-    ); */
-
-    // Version temporaire sans Recharts
-    return (
-      <div className="h-64 flex items-center justify-center bg-gray-50 border rounded">
-        <p className="text-gray-500">Graphique en camembert des présences/absences/retards</p>
-      </div>
-    );
-  };
+  const renderPieChart = () => (
+    <ResponsiveContainer width="100%" height={300}>
+      <PieChart>
+        <Pie
+          data={statusData}
+          cx="50%"
+          cy="50%"
+          labelLine={false}
+          outerRadius={100}
+          dataKey="value"
+          label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+        >
+          {statusData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={entry.color} />
+          ))}
+        </Pie>
+        <Tooltip formatter={(value) => [value, 'Nombre']} />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
 
   return (
     <div className="space-y-4">
@@ -100,31 +99,28 @@ export const DepartmentPerformanceChart: React.FC<{ departmentStats: DepartmentS
     .sort((a, b) => b.attendanceRate - a.attendanceRate)
     .slice(0, 5);
 
-  const renderBarChart = () => {
-    // Si vous utilisez Recharts, décommentez ce code
-    /* return (
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart
-          data={sortedDepartments}
-          margin={{ top: 20, right: 30, left: 20, bottom: 60 }}
-        >
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="name" tick={{ fontSize: 12 }} height={60} interval={0} angle={-45} textAnchor="end" />
-          <YAxis domain={[0, 100]} />
-          <Tooltip formatter={(value) => [`${value}%`, 'Taux de présence']} />
-          <Legend />
-          <Bar dataKey="attendanceRate" name="Taux de présence (%)" fill="#4ade80" />
-        </BarChart>
-      </ResponsiveContainer>
-    ); */
-
-    // Version temporaire sans Recharts
-    return (
-      <div className="h-64 flex items-center justify-center bg-gray-50 border rounded">
-        <p className="text-gray-500">Graphique à barres des performances par département</p>
-      </div>
-    );
-  };
+  const renderBarChart = () => (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={sortedDepartments}
+        margin={{ top: 20, right: 30, left: 20, bottom: 60 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="name"
+          tick={{ fontSize: 12 }}
+          height={60}
+          interval={0}
+          angle={-45}
+          textAnchor="end"
+        />
+        <YAxis domain={[0, 100]} />
+        <Tooltip formatter={(value) => [`${value}%`, 'Taux de présence']} />
+        <Legend />
+        <Bar dataKey="attendanceRate" name="Taux de présence (%)" fill="#4ade80" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
 
   return (
     <div className="space-y-4">
@@ -140,31 +136,28 @@ export const WorkHoursChart: React.FC<{ departmentStats: DepartmentStat[] }> = (
     .sort((a, b) => b.workHours - a.workHours)
     .slice(0, 5);
 
-  const renderHoursChart = () => {
-    // Si vous utilisez Recharts, décommentez ce code
-    /* return (
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart
-          data={sortedByHours}
-          margin={{ top: 20, right: 30, left: 20, bottom: 60 }}
-        >
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="name" tick={{ fontSize: 12 }} height={60} interval={0} angle={-45} textAnchor="end" />
-          <YAxis />
-          <Tooltip formatter={(value) => [`${value.toFixed(1)}h`, 'Heures travaillées']} />
-          <Legend />
-          <Bar dataKey="workHours" name="Heures travaillées" fill="#60a5fa" />
-        </BarChart>
-      </ResponsiveContainer>
-    ); */
-
-    // Version temporaire sans Recharts
-    return (
-      <div className="h-64 flex items-center justify-center bg-gray-50 border rounded">
-        <p className="text-gray-500">Graphique des heures travaillées par département</p>
-      </div>
-    );
-  };
+  const renderHoursChart = () => (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={sortedByHours}
+        margin={{ top: 20, right: 30, left: 20, bottom: 60 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="name"
+          tick={{ fontSize: 12 }}
+          height={60}
+          interval={0}
+          angle={-45}
+          textAnchor="end"
+        />
+        <YAxis />
+        <Tooltip formatter={(value: number) => [`${value.toFixed(1)}h`, 'Heures travaillées']} />
+        <Legend />
+        <Bar dataKey="workHours" name="Heures travaillées" fill="#60a5fa" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
 
   return (
     <div className="space-y-4">

--- a/src/components/dashboard/RemindersWidget.tsx
+++ b/src/components/dashboard/RemindersWidget.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Bell, AlertCircle, CalendarCheck } from 'lucide-react'
+import Card from '../ui/card'
+
+interface Reminder {
+  id: number
+  icon: React.ComponentType<any>
+  title: string
+  time: string
+}
+
+const defaultReminders: Reminder[] = [
+  { id: 1, icon: CalendarCheck, title: "Réunion d'équipe", time: 'Aujourd\'hui 14:00' },
+  { id: 2, icon: AlertCircle, title: 'Soumettre rapport mensuel', time: 'Demain' }
+]
+
+export default function RemindersWidget() {
+  return (
+    <Card>
+      <h2 className="text-lg font-semibold mb-4 flex items-center">
+        <Bell className="h-5 w-5 mr-2" /> Rappels
+      </h2>
+      <ul className="space-y-3">
+        {defaultReminders.map((reminder) => {
+          const Icon = reminder.icon
+          return (
+            <li key={reminder.id} className="flex items-center">
+              <Icon className="h-4 w-4 text-primary-600 mr-2" />
+              <span className="text-sm text-foreground">{reminder.title}</span>
+              <span className="ml-auto text-xs text-gray-500">{reminder.time}</span>
+            </li>
+          )
+        })}
+      </ul>
+    </Card>
+  )
+}
+

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -1,34 +1,28 @@
 import React, { ReactNode } from 'react';
+import Sidebar, { SidebarSection } from './Sidebar';
+import Header from './Header';
 
 interface DefaultLayoutProps {
   children: ReactNode;
 }
 
+const defaultSections: SidebarSection[] = [
+  {
+    title: 'General',
+    items: [
+      { label: 'Dashboard', href: '/dashboard' },
+      { label: 'Reports', href: '/reports' },
+    ],
+  },
+];
+
 export default function DefaultLayout({ children }: DefaultLayoutProps) {
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="flex min-h-screen">
-        {/* Sidebar would go here in a real implementation */}
-        <div className="hidden md:block md:w-64 bg-primary-900 text-white p-4">
-          {/* Sidebar content */}
-          <div className="py-4 text-xl font-bold mb-6">PointFlex</div>
-          <nav>
-            {/* Navigation items */}
-          </nav>
-        </div>
-        
-        {/* Main content */}
-        <div className="flex-1">
-          {/* Header would go here in a real implementation */}
-          <header className="bg-white border-b h-16 flex items-center px-6 shadow-sm">
-            {/* Header content */}
-          </header>
-          
-          {/* Page content */}
-          <main className="p-0">
-            {children}
-          </main>
-        </div>
+    <div className="flex min-h-screen bg-background text-foreground">
+      <Sidebar sections={defaultSections} />
+      <div className="flex flex-1 flex-col">
+        <Header />
+        <main className="flex-1 overflow-y-auto p-4">{children}</main>
       </div>
     </div>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Menu, Bell } from 'lucide-react';
+import ThemeToggle from '../ThemeToggle';
+import Button from '../ui/button';
+
+interface HeaderProps {
+  onMenuToggle?: () => void;
+}
+
+export function Header({ onMenuToggle }: HeaderProps) {
+  return (
+    <header className="flex items-center justify-between h-16 px-4 border-b border-border bg-background">
+      <div className="flex items-center gap-2">
+        <Button color="secondary" size="sm" onClick={onMenuToggle} icon={<Menu className="w-4 h-4" />} />
+        <input
+          type="search"
+          placeholder="Search..."
+          className="h-8 px-3 rounded-md border border-border bg-background text-sm"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Button color="secondary" size="sm" icon={<Bell className="w-4 h-4" />} />
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { cn } from '../../utils/cn';
+
+export interface SidebarItem {
+  label: string;
+  href: string;
+  icon?: React.ReactNode;
+}
+
+export interface SidebarSection {
+  title: string;
+  items: SidebarItem[];
+}
+
+interface SidebarProps {
+  sections: SidebarSection[];
+}
+
+export function Sidebar({ sections }: SidebarProps) {
+  return (
+    <aside className="w-64 bg-primary-900 text-white hidden md:block">
+      {sections.map((section) => (
+        <div key={section.title} className="mt-4">
+          <h2 className="px-4 text-sm font-semibold text-white/70">{section.title}</h2>
+          <nav className="mt-2">
+            {section.items.map((item) => (
+              <NavLink
+                key={item.href}
+                to={item.href}
+                className={({ isActive }) =>
+                  cn(
+                    'flex items-center px-4 py-2 text-sm hover:bg-primary-800',
+                    isActive && 'bg-primary-700'
+                  )
+                }
+              >
+                {item.icon && <span className="mr-2">{item.icon}</span>}
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      ))}
+    </aside>
+  );
+}
+
+export default Sidebar;

--- a/src/components/shared/DataTable.tsx
+++ b/src/components/shared/DataTable.tsx
@@ -1,79 +1,238 @@
-import React from 'react'
-import { Search, Filter } from 'lucide-react'
+import React, { useState, useMemo } from 'react'
+import { Search, Filter, LayoutGrid, Table as TableIcon, ChevronDown, ChevronUp } from 'lucide-react'
 
 interface Column {
   key: string
   label: string
   render?: (value: any, row: any) => React.ReactNode
+  sortable?: boolean
+  filterOptions?: { label: string; value: string }[]
 }
 
 interface DataTableProps {
   data: any[]
   columns: Column[]
-  searchTerm: string
-  onSearchChange: (term: string) => void
+  searchTerm?: string
+  onSearchChange?: (term: string) => void
   emptyMessage?: string
   actions?: (row: any) => React.ReactNode
+  pageSize?: number
+  enableCardView?: boolean
 }
 
-export default function DataTable({ 
-  data, 
-  columns, 
-  searchTerm, 
-  onSearchChange, 
+export default function DataTable({
+  data,
+  columns,
+  searchTerm = '',
+  onSearchChange = () => {},
   emptyMessage = "Aucune donnée",
-  actions 
+  actions,
+  pageSize = 10,
+  enableCardView = false
 }: DataTableProps) {
+  const [sortConfig, setSortConfig] = useState<{ key: string; direction: 'asc' | 'desc' } | null>(null)
+  const [filters, setFilters] = useState<Record<string, string>>({})
+  const [currentPage, setCurrentPage] = useState(1)
+  const [viewMode, setViewMode] = useState<'table' | 'cards'>(enableCardView ? 'table' : 'table')
+
+  const handleSort = (column: Column) => {
+    if (!column.sortable) return
+    let direction: 'asc' | 'desc' = 'asc'
+    if (sortConfig && sortConfig.key === column.key && sortConfig.direction === 'asc') {
+      direction = 'desc'
+    }
+    setSortConfig({ key: column.key, direction })
+  }
+
+  const handleFilterChange = (key: string, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }))
+    setCurrentPage(1)
+  }
+
+  const filteredData = useMemo(() => {
+    let temp = [...data]
+    if (searchTerm) {
+      temp = temp.filter((row) =>
+        Object.values(row).some((val) =>
+          String(val).toLowerCase().includes(searchTerm.toLowerCase())
+        )
+      )
+    }
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value) {
+        temp = temp.filter((row) => String(row[key]) === value)
+      }
+    })
+    if (sortConfig) {
+      temp.sort((a, b) => {
+        const aVal = a[sortConfig.key]
+        const bVal = b[sortConfig.key]
+        if (aVal < bVal) return sortConfig.direction === 'asc' ? -1 : 1
+        if (aVal > bVal) return sortConfig.direction === 'asc' ? 1 : -1
+        return 0
+      })
+    }
+    return temp
+  }, [data, searchTerm, filters, sortConfig])
+
+  const pageCount = Math.ceil(filteredData.length / pageSize) || 1
+  const paginatedData = filteredData.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+
   return (
     <div className="card overflow-hidden">
-      <div className="p-4 border-b border-gray-200">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-          <input
-            type="text"
-            placeholder="Rechercher..."
-            value={searchTerm}
-            onChange={(e) => onSearchChange(e.target.value)}
-            className="input-field pl-10"
-          />
+      <div className="p-4 border-b border-gray-200 space-y-2">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Rechercher..."
+              value={searchTerm}
+              onChange={(e) => {
+                setCurrentPage(1)
+                onSearchChange(e.target.value)
+              }}
+              className="input-field pl-10"
+            />
+          </div>
+          {enableCardView && (
+            <div className="flex items-center gap-2">
+              <button
+                aria-label="Vue tableau"
+                className={`btn-secondary p-2 ${viewMode === 'table' ? 'bg-primary-50 text-primary-700' : ''}`}
+                onClick={() => setViewMode('table')}
+              >
+                <TableIcon className="h-4 w-4" />
+              </button>
+              <button
+                aria-label="Vue cartes"
+                className={`btn-secondary p-2 ${viewMode === 'cards' ? 'bg-primary-50 text-primary-700' : ''}`}
+                onClick={() => setViewMode('cards')}
+              >
+                <LayoutGrid className="h-4 w-4" />
+              </button>
+            </div>
+          )}
         </div>
+        {columns.some((c) => c.filterOptions) && (
+          <div className="flex flex-wrap gap-2">
+            {columns.map((column) =>
+              column.filterOptions ? (
+                <select
+                  key={column.key}
+                  value={filters[column.key] || ''}
+                  onChange={(e) => handleFilterChange(column.key, e.target.value)}
+                  className="input-field w-auto"
+                >
+                  <option value="">{column.label}</option>
+                  {column.filterOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              ) : null
+            )}
+          </div>
+        )}
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              {columns.map((column) => (
-                <th key={column.key} className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  {column.label}
-                </th>
-              ))}
-              {actions && <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>}
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {data.map((row, index) => (
-              <tr key={index} className="hover:bg-gray-50">
+      {viewMode === 'table' ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
                 {columns.map((column) => (
-                  <td key={column.key} className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {column.render ? column.render(row[column.key], row) : row[column.key]}
-                  </td>
+                  <th
+                    key={column.key}
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase cursor-pointer select-none"
+                    onClick={() => handleSort(column)}
+                  >
+                    <span className="inline-flex items-center">
+                      {column.label}
+                      {sortConfig?.key === column.key && (
+                        sortConfig.direction === 'asc' ? (
+                          <ChevronUp className="ml-1 h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="ml-1 h-3 w-3" />
+                        )
+                      )}
+                    </span>
+                  </th>
                 ))}
-                {actions && (
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    {actions(row)}
-                  </td>
-                )}
+                {actions && <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>}
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {paginatedData.map((row, index) => (
+                <tr key={index} className="hover:bg-gray-50">
+                  {columns.map((column) => (
+                    <td key={column.key} className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {column.render ? column.render(row[column.key], row) : row[column.key]}
+                    </td>
+                  ))}
+                  {actions && (
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                      {actions(row)}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+          {paginatedData.map((row, index) => (
+            <div key={index} className="border rounded-lg p-4 shadow-sm">
+              {columns.map((column) => (
+                <div key={column.key} className="mb-2">
+                  <div className="text-xs font-medium text-gray-500">{column.label}</div>
+                  <div className="text-sm">
+                    {column.render ? column.render(row[column.key], row) : row[column.key]}
+                  </div>
+                </div>
+              ))}
+              {actions && <div className="mt-2 text-right">{actions(row)}</div>}
+            </div>
+          ))}
+        </div>
+      )}
 
-      {data.length === 0 && (
+      {filteredData.length === 0 && (
         <div className="text-center py-12">
           <Filter className="mx-auto h-12 w-12 text-gray-400" />
           <h3 className="mt-2 text-sm font-medium text-gray-900">{emptyMessage}</h3>
+        </div>
+      )}
+
+      {filteredData.length > pageSize && (
+        <div className="flex justify-center py-4">
+          <nav className="pagination">
+            <button
+              className="pagination-item"
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+            >
+              Précédent
+            </button>
+            {Array.from({ length: pageCount }, (_, i) => (
+              <button
+                key={i + 1}
+                onClick={() => setCurrentPage(i + 1)}
+                className={`pagination-item ${currentPage === i + 1 ? 'active' : ''}`}
+              >
+                {i + 1}
+              </button>
+            ))}
+            <button
+              className="pagination-item"
+              onClick={() => setCurrentPage((p) => Math.min(pageCount, p + 1))}
+              disabled={currentPage === pageCount}
+            >
+              Suivant
+            </button>
+          </nav>
         </div>
       )}
     </div>

--- a/src/components/shared/Modal.tsx
+++ b/src/components/shared/Modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { X } from 'lucide-react'
 
 interface ModalProps {
@@ -10,7 +10,18 @@ interface ModalProps {
 }
 
 export default function Modal({ isOpen, onClose, title, children, size = 'md' }: ModalProps) {
-  if (!isOpen) return null
+  const [visible, setVisible] = useState(isOpen)
+
+  useEffect(() => {
+    if (isOpen) {
+      setVisible(true)
+    } else {
+      const timer = setTimeout(() => setVisible(false), 200)
+      return () => clearTimeout(timer)
+    }
+  }, [isOpen])
+
+  if (!visible) return null
 
   const sizeClasses = {
     sm: 'max-w-md',
@@ -22,8 +33,13 @@ export default function Modal({ isOpen, onClose, title, children, size = 'md' }:
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen px-4">
-        <div className="fixed inset-0 bg-gray-600 bg-opacity-75" onClick={onClose} />
-        <div className={`relative bg-white rounded-lg ${sizeClasses[size]} w-full p-6 max-h-screen overflow-y-auto`}>
+        <div
+          className={`fixed inset-0 bg-gray-600 bg-opacity-75 transition-opacity duration-200 ${isOpen ? 'opacity-100' : 'opacity-0'}`}
+          onClick={onClose}
+        />
+        <div
+          className={`relative bg-white rounded-lg ${sizeClasses[size]} w-full p-6 max-h-screen overflow-y-auto transform transition-all duration-200 ${isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}`}
+        >
           <div className="flex items-center justify-between mb-6">
             <h2 className="text-xl font-bold text-gray-900">{title}</h2>
             <button onClick={onClose} className="text-gray-400 hover:text-gray-600">

--- a/src/components/shared/SkeletonTable.tsx
+++ b/src/components/shared/SkeletonTable.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import Skeleton from '../ui/skeleton'
+
+interface SkeletonTableProps {
+  columns?: number
+  rows?: number
+}
+
+export default function SkeletonTable({ columns = 5, rows = 5 }: SkeletonTableProps) {
+  return (
+    <div className="border rounded-md divide-y divide-gray-200">
+      <div
+        className="grid gap-4 p-4"
+        style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+      >
+        {[...Array(columns)].map((_, i) => (
+          <Skeleton key={i} className="h-4 w-full" />
+        ))}
+      </div>
+      {[...Array(rows)].map((_, r) => (
+        <div
+          key={r}
+          className="grid gap-4 p-4"
+          style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+        >
+          {[...Array(columns)].map((_, c) => (
+            <Skeleton key={c} className="h-4 w-full" />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/shared/StatusBadge.tsx
+++ b/src/components/shared/StatusBadge.tsx
@@ -1,42 +1,43 @@
-import React from 'react'
-import { CheckCircle, XCircle, AlertTriangle, Clock } from 'lucide-react'
+import React from 'react';
+import { CheckCircle, XCircle, AlertTriangle, Clock } from 'lucide-react';
+import Badge from '../ui/badge';
 
 interface StatusBadgeProps {
-  status: 'active' | 'inactive' | 'pending' | 'warning'
-  text?: string
+  status: 'active' | 'inactive' | 'pending' | 'warning';
+  text?: string;
 }
 
-export default function StatusBadge({ status, text }: StatusBadgeProps) {
-  const configs = {
-    active: {
-      icon: CheckCircle,
-      className: 'bg-green-100 text-green-800',
-      defaultText: 'Actif'
-    },
-    inactive: {
-      icon: XCircle,
-      className: 'bg-red-100 text-red-800',
-      defaultText: 'Inactif'
-    },
-    pending: {
-      icon: Clock,
-      className: 'bg-yellow-100 text-yellow-800',
-      defaultText: 'En attente'
-    },
-    warning: {
-      icon: AlertTriangle,
-      className: 'bg-orange-100 text-orange-800',
-      defaultText: 'Attention'
-    }
-  }
+const configs = {
+  active: {
+    icon: CheckCircle,
+    color: 'success',
+    defaultText: 'Actif',
+  },
+  inactive: {
+    icon: XCircle,
+    color: 'danger',
+    defaultText: 'Inactif',
+  },
+  pending: {
+    icon: Clock,
+    color: 'pending',
+    defaultText: 'En attente',
+  },
+  warning: {
+    icon: AlertTriangle,
+    color: 'warning',
+    defaultText: 'Attention',
+  },
+};
 
-  const config = configs[status]
-  const Icon = config.icon
+export default function StatusBadge({ status, text }: StatusBadgeProps) {
+  const config = configs[status];
+  const Icon = config.icon;
 
   return (
-    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${config.className}`}>
+    <Badge color={config.color as any} className="inline-flex items-center">
       <Icon className="h-3 w-3 mr-1" />
       {text || config.defaultText}
-    </span>
-  )
+    </Badge>
+  );
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode, HTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  color?:
+    | 'primary'
+    | 'accent'
+    | 'secondary'
+    | 'success'
+    | 'danger'
+    | 'warning'
+    | 'pending';
+  children: ReactNode;
+}
+
+const baseStyles = 'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium';
+
+const colorStyles: Record<string, string> = {
+  primary: 'bg-primary-100 text-primary-800',
+  accent: 'bg-accent-100 text-accent-800',
+  secondary: 'bg-gray-200 text-gray-800',
+  success: 'bg-green-100 text-green-800',
+  danger: 'bg-red-100 text-red-800',
+  warning: 'bg-orange-100 text-orange-800',
+  pending: 'bg-yellow-100 text-yellow-800',
+};
+
+export function Badge({ color = 'primary', children, className, ...props }: BadgeProps) {
+  return (
+    <span className={cn(baseStyles, colorStyles[color], className)} {...props}>
+      {children}
+    </span>
+  );
+}
+
+export default Badge;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,45 @@
+import React, { ReactNode } from 'react';
+import { cn } from '../../utils/cn';
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  color?: 'primary' | 'secondary' | 'accent';
+  size?: 'sm' | 'md' | 'lg';
+  icon?: ReactNode;
+  children?: ReactNode;
+};
+
+const baseStyles =
+  `inline-flex items-center justify-center rounded-md font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:pointer-events-none`;
+
+const colorStyles: Record<string, string> = {
+  primary: 'bg-primary-600 text-white hover:bg-primary-700 focus-visible:ring-primary-600',
+  secondary: 'bg-gray-200 text-foreground hover:bg-gray-300 focus-visible:ring-gray-300',
+  accent: 'bg-accent-600 text-white hover:bg-accent-700 focus-visible:ring-accent-600',
+};
+
+const sizeStyles: Record<string, string> = {
+  sm: 'h-8 px-3 text-sm',
+  md: 'h-10 px-4 text-sm',
+  lg: 'h-12 px-6 text-base',
+};
+
+export function Button({
+  color = 'primary',
+  size = 'md',
+  icon,
+  children,
+  className,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={cn(baseStyles, colorStyles[color], sizeStyles[size], className)}
+      {...props}
+    >
+      {icon && <span className={children ? 'mr-2' : ''}>{icon}</span>}
+      {children}
+    </button>
+  );
+}
+
+export default Button;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode, HTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  color?: 'default' | 'accent';
+  children: ReactNode;
+}
+
+const baseStyles = 'rounded-xl border border-border p-6 shadow-sm';
+
+const colorStyles: Record<string, string> = {
+  default: 'bg-white',
+  accent: 'bg-accent-50',
+};
+
+export function Card({ color = 'default', children, className, ...props }: CardProps) {
+  return (
+    <div className={cn(baseStyles, colorStyles[color], className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export default Card;

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { cn } from '../../utils/cn'
+
+interface SkeletonProps {
+  className?: string
+}
+
+export default function Skeleton({ className }: SkeletonProps) {
+  return <div className={cn('animate-pulse rounded-md bg-gray-200 dark:bg-gray-700', className)} />
+}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,82 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+type Density = 'comfortable' | 'compact';
+
+interface TenantColors {
+  primary?: Partial<Record<'50' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900', string>>;
+  background?: string;
+}
+
+interface ThemeContextValue {
+  theme: Theme;
+  density: Density;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+  setDensity: (density: Density) => void;
+  setTenantColors: (colors: TenantColors) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem('theme') as Theme) || 'light');
+  const [density, setDensityState] = useState<Density>(() => (localStorage.getItem('density') as Density) || 'comfortable');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') root.classList.add('dark');
+    else root.classList.remove('dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.dataset.density = density;
+    localStorage.setItem('density', density);
+  }, [density]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const storedPrimary = localStorage.getItem('tenant-primary');
+    const storedBackground = localStorage.getItem('tenant-background');
+    if (storedBackground) {
+      root.style.setProperty('--color-background', storedBackground);
+    }
+    if (storedPrimary) {
+      const palette = JSON.parse(storedPrimary);
+      Object.entries(palette).forEach(([shade, value]) => {
+        root.style.setProperty(`--color-primary-${shade}`, value as string);
+      });
+    }
+  }, []);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  const setDensity = (d: Density) => setDensityState(d);
+
+  const setTenantColors = (colors: TenantColors) => {
+    const root = document.documentElement;
+    if (colors.background) {
+      root.style.setProperty('--color-background', colors.background);
+      localStorage.setItem('tenant-background', colors.background);
+    }
+    if (colors.primary) {
+      Object.entries(colors.primary).forEach(([shade, value]) => {
+        root.style.setProperty(`--color-primary-${shade}`, value);
+      });
+      localStorage.setItem('tenant-primary', JSON.stringify(colors.primary));
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, density, setTheme, toggleTheme, setDensity, setTenantColors }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within a ThemeProvider');
+  return ctx;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,26 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --color-primary-50: #eff6ff;
+    --color-primary-100: #dbeafe;
+    --color-primary-200: #bfdbfe;
+    --color-primary-300: #93c5fd;
+    --color-primary-400: #60a5fa;
+    --color-primary-500: #3b82f6;
+    --color-primary-600: #2563eb;
+    --color-primary-700: #1d4ed8;
+    --color-primary-800: #1e40af;
+    --color-primary-900: #1e3a8a;
+    --color-background: #f9fafb;
+    --color-foreground: #111827;
+  }
+
+  .dark {
+    --color-background: #111827;
+    --color-foreground: #f9fafb;
+  }
+
   * {
     @apply border-border;
   }
@@ -10,31 +30,36 @@
     @apply bg-background text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
+
+  :focus-visible {
+    outline: 2px solid var(--color-primary-600);
+    outline-offset: 2px;
+  }
 }
 
 @layer components {
   .btn-primary {
-    @apply bg-primary-600 hover:bg-primary-700 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2;
+    @apply bg-primary-600 hover:bg-primary-700 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2;
   }
   
   .btn-secondary {
-    @apply bg-gray-200 hover:bg-gray-300 text-gray-900 font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2;
+    @apply bg-gray-200 hover:bg-gray-300 text-gray-900 font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2;
   }
   
   .btn-warning {
-    @apply bg-yellow-500 hover:bg-yellow-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2;
+    @apply bg-yellow-500 hover:bg-yellow-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2;
   }
   
   .btn-danger {
-    @apply bg-red-500 hover:bg-red-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2;
+    @apply bg-red-500 hover:bg-red-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2;
   }
   
   .btn-success {
-    @apply bg-green-500 hover:bg-green-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2;
+    @apply bg-green-500 hover:bg-green-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2;
   }
   
   .input-field {
-    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all duration-200;
+    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:border-transparent transition-all duration-200;
   }
   
   .card {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,18 +2,26 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import { I18nProvider } from './contexts/I18nContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 import './index.css'
 import { Toaster } from 'react-hot-toast'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <I18nProvider>
-      <App />
-    </I18nProvider>
+    <ThemeProvider>
+      <I18nProvider>
+        <App />
+      </I18nProvider>
+    </ThemeProvider>
     <Toaster
       position="top-right"
       toastOptions={{
         duration: 4000,
+        className: 'animate-slide-in',
+        ariaProps: { role: 'status', 'aria-live': 'polite' },
+        success: { icon: '✅' },
+        error: { icon: '❌' },
+        loading: { icon: '⏳' },
         style: {
           background: '#363636',
           color: '#fff',

--- a/src/pages/Attendance.tsx
+++ b/src/pages/Attendance.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react'
-import CheckInComponent from '../components/CheckIn'
+import React, { useState } from 'react'
 import { attendanceService } from '../services/api'
+import { toast } from 'react-hot-toast'
 import { Coffee, LogOut, Loader } from 'lucide-react'
-import toast from 'react-hot-toast'
+import Card from '../components/ui/card'
+import Button from '../components/ui/button'
+import CheckInComponent from '../components/CheckIn'
 
-export default function AttendancePage() {
+export default function Attendance() {
   const [onBreak, setOnBreak] = useState(false)
   const [loadingPause, setLoadingPause] = useState(false)
   const [loadingCheckout, setLoadingCheckout] = useState(false)
@@ -13,10 +15,10 @@ export default function AttendancePage() {
     setLoadingPause(true)
     try {
       await attendanceService.startPause()
-      toast.success('Pause démarrée')
       setOnBreak(true)
+      toast.success('Pause démarrée avec succès!')
     } catch (err) {
-      toast.error('Erreur lors du démarrage de la pause')
+      toast.error("Erreur lors du démarrage de la pause")
     } finally {
       setLoadingPause(false)
     }
@@ -26,10 +28,10 @@ export default function AttendancePage() {
     setLoadingPause(true)
     try {
       await attendanceService.endPause()
-      toast.success('Pause terminée')
       setOnBreak(false)
+      toast.success('Pause terminée avec succès!')
     } catch (err) {
-      toast.error('Erreur lors de la fin de la pause')
+      toast.error("Erreur lors de la fin de la pause")
     } finally {
       setLoadingPause(false)
     }
@@ -52,26 +54,26 @@ export default function AttendancePage() {
       <CheckInComponent />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="card text-center">
+        <Card className="text-center">
           <div className="mb-4 flex justify-center">
             <Coffee className="h-8 w-8 text-yellow-600" />
           </div>
           {onBreak ? (
-            <button onClick={endPause} disabled={loadingPause} className="btn-primary">
+            <Button onClick={endPause} disabled={loadingPause}>
               {loadingPause ? <Loader className="animate-spin h-4 w-4" /> : 'Terminer la pause'}
-            </button>
+            </Button>
           ) : (
-            <button onClick={startPause} disabled={loadingPause} className="btn-primary">
+            <Button onClick={startPause} disabled={loadingPause}>
               {loadingPause ? <Loader className="animate-spin h-4 w-4" /> : 'Démarrer une pause'}
-            </button>
+            </Button>
           )}
-        </div>
+        </Card>
 
-        <div className="card text-center">
+        <Card className="text-center">
           <div className="mb-4 flex justify-center">
             <LogOut className="h-8 w-8 text-red-600" />
           </div>
-          <button onClick={checkout} disabled={loadingCheckout} className="btn-primary disabled:opacity-50 disabled:cursor-not-allowed">
+          <Button onClick={checkout} disabled={loadingCheckout}>
             {loadingCheckout ? (
               <div className="flex items-center justify-center">
                 <Loader className="animate-spin h-5 w-5 mr-2" />
@@ -83,8 +85,8 @@ export default function AttendancePage() {
                 Enregistrer ma sortie
               </>
             )}
-          </button>
-        </div>
+          </Button>
+        </Card>
       </div>
     </div>
   )

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,16 +3,19 @@ import { attendanceService } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
 import AttendanceChart from '../components/AttendanceChart'
 import QuickActions from '../components/QuickActions'
-import { 
-  Clock, 
-  MapPin, 
-  Calendar, 
+import RemindersWidget from '../components/dashboard/RemindersWidget'
+import { Button } from '../components/ui/button'
+import { getRoleStyle } from '../utils/roleStyles'
+import {
+  Clock,
+  MapPin,
+  Calendar,
   TrendingUp,
   CheckCircle,
   XCircle,
   AlertTriangle,
-  Users,
-  Building
+  Building,
+  Settings
 } from 'lucide-react'
 import { format, startOfMonth, endOfMonth, subDays } from 'date-fns'
 import { fr } from 'date-fns/locale'
@@ -35,14 +38,41 @@ interface Stats {
   average_hours: number
 }
 
+interface WidgetVisibility {
+  presence: boolean
+  reminders: boolean
+  quickActions: boolean
+}
+
 export default function Dashboard() {
-  const { user, isAdmin, isSuperAdmin } = useAuth()
+  const { user } = useAuth()
+  const roleInfo = getRoleStyle(user?.role)
+  const RoleIcon = roleInfo.icon
+
   const [attendanceRecords, setAttendanceRecords] = useState<AttendanceRecord[]>([])
   const [stats, setStats] = useState<Stats | null>(null)
   const [loading, setLoading] = useState(true)
+  const [chartData, setChartData] = useState<Array<{ date: string; present: number; late: number; absent: number }>>([])
+  const [widgets, setWidgets] = useState<WidgetVisibility>(() => {
+    try {
+      const saved = localStorage.getItem('dashboard-widgets')
+      return saved
+        ? JSON.parse(saved)
+        : { presence: true, reminders: true, quickActions: true }
+    } catch {
+      return { presence: true, reminders: true, quickActions: true }
+    }
+  })
+  const [configOpen, setConfigOpen] = useState(false)
 
-  const [chartData, setChartData] = useState<Array<{date: string; present: number; late: number; absent: number}>>([])
-  
+  const toggleWidget = (key: keyof WidgetVisibility) => {
+    setWidgets((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  useEffect(() => {
+    localStorage.setItem('dashboard-widgets', JSON.stringify(widgets))
+  }, [widgets])
+
   useEffect(() => {
     loadData()
   }, [])
@@ -51,36 +81,31 @@ export default function Dashboard() {
     try {
       const startDate = format(startOfMonth(new Date()), 'yyyy-MM-dd')
       const endDate = format(endOfMonth(new Date()), 'yyyy-MM-dd')
-      
       const [attendanceResponse, statsResponse, last7DaysResponse] = await Promise.all([
         attendanceService.getAttendance(startDate, endDate),
         attendanceService.getStats(),
         attendanceService.getLast7DaysStats()
       ])
-      
       setAttendanceRecords(attendanceResponse.data.records)
       setStats(statsResponse.data.stats)
-      
-      // Traiter les données des 7 derniers jours
       if (last7DaysResponse.data.stats && Array.isArray(last7DaysResponse.data.stats)) {
-        setChartData(last7DaysResponse.data.stats.map((day: any) => ({
-          date: day.date,
-          present: day.present,
-          late: day.late,
-          absent: day.absent
-        })))
+        setChartData(
+          last7DaysResponse.data.stats.map((day: any) => ({
+            date: day.date,
+            present: day.present,
+            late: day.late,
+            absent: day.absent
+          }))
+        )
       }
     } catch (error) {
       console.error('Erreur lors du chargement des données:', error)
-      
-      // En cas d'erreur, générer des données de démonstration
       generateFallbackChartData()
     } finally {
       setLoading(false)
     }
   }
 
-  // Générer des données pour le graphique comme fallback en cas d'erreur
   const generateFallbackChartData = () => {
     const last7Days = Array.from({ length: 7 }, (_, i) => {
       const date = subDays(new Date(), 6 - i)
@@ -103,18 +128,18 @@ export default function Dashboard() {
 
   const getTodayStatus = () => {
     const today = format(new Date(), 'yyyy-MM-dd')
-    const todayRecord = attendanceRecords.find(r => r.date_pointage === today)
-    
+    const todayRecord = attendanceRecords.find((r) => r.date_pointage === today)
+
     if (!todayRecord) {
       return {
         status: 'not_checked',
-        message: 'Vous n\'avez pas encore pointé aujourd\'hui',
+        message: "Vous n'avez pas encore pointé aujourd'hui",
         color: 'text-yellow-600',
         bgColor: 'bg-yellow-50',
         borderColor: 'border-yellow-200'
       }
     }
-    
+
     if (todayRecord.statut === 'present') {
       return {
         status: 'present',
@@ -124,7 +149,7 @@ export default function Dashboard() {
         borderColor: 'border-green-200'
       }
     }
-    
+
     return {
       status: 'late',
       message: `Pointé à ${todayRecord.heure_arrivee} - En retard`,
@@ -145,8 +170,39 @@ export default function Dashboard() {
   const todayStatus = getTodayStatus()
 
   return (
-    <div className="space-y-6">
-      {/* Header personnalisé */}
+    <div className="space-y-6 relative">
+      <div className="flex justify-end">
+        <Button
+          color="secondary"
+          size="sm"
+          icon={<Settings className="h-4 w-4" />}
+          onClick={() => setConfigOpen(!configOpen)}
+        >
+          Widgets
+        </Button>
+      </div>
+      {configOpen && (
+        <div className="absolute right-0 mt-2 w-64 z-20">
+          <div className="card p-4">
+            <h3 className="text-sm font-medium mb-2">Modules</h3>
+            <div className="space-y-2">
+              {(['presence', 'reminders', 'quickActions'] as const).map((key) => (
+                <label key={key} className="flex items-center space-x-2">
+                  <input
+                    type="checkbox"
+                    checked={widgets[key]}
+                    onChange={() => toggleWidget(key)}
+                  />
+                  <span className="capitalize text-sm">
+                    {key === 'quickActions' ? 'actions' : key}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="bg-gradient-to-r from-primary-600 to-primary-700 rounded-xl p-6 text-white">
         <div className="flex items-center justify-between">
           <div>
@@ -167,181 +223,167 @@ export default function Dashboard() {
             <div className="text-3xl font-bold">
               {format(new Date(), 'HH:mm')}
             </div>
-            <div className="text-primary-200 text-sm">
-              {user?.role === 'superadmin' ? 'Super Admin' : 
-               user?.role === 'admin_rh' ? 'Administrateur RH' : 
-               user?.role === 'chef_service' ? 'Chef de Service' : 
-               user?.role === 'chef_projet' ? 'Chef de Projet' : 
-               user?.role === 'manager' ? 'Manager' : 
-               user?.role === 'auditeur' ? 'Auditeur' : 'Employé'}
+            <div className="mt-2">
+              <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${roleInfo.bg} ${roleInfo.color}`}>
+                <RoleIcon className="h-4 w-4 mr-1" />
+                {roleInfo.label}
+              </span>
             </div>
           </div>
         </div>
       </div>
 
-      {/* Statut du jour */}
-      <div className={`${todayStatus.bgColor} ${todayStatus.borderColor} border rounded-lg p-4`}>
-        <div className="flex items-center space-x-3">
-          {todayStatus.status === 'present' && <CheckCircle className="h-6 w-6 text-green-600" />}
-          {todayStatus.status === 'late' && <AlertTriangle className="h-6 w-6 text-orange-600" />}
-          {todayStatus.status === 'not_checked' && <Clock className="h-6 w-6 text-yellow-600" />}
-          <div>
-            <h3 className={`font-medium ${todayStatus.color}`}>
-              Statut du jour
-            </h3>
-            <p className={`text-sm ${todayStatus.color}`}>
-              {todayStatus.message}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* Stats Cards */}
-      {stats && (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <div className="card hover:shadow-md transition-shadow">
-            <div className="flex items-center">
-              <div className="p-3 bg-green-100 rounded-lg">
-                <CheckCircle className="h-6 w-6 text-green-600" />
-              </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Jours présents</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.present_days}</p>
-                <p className="text-xs text-green-600">Ce mois-ci</p>
+      {widgets.presence && (
+        <>
+          <div className={`${todayStatus.bgColor} ${todayStatus.borderColor} border rounded-lg p-4`}>
+            <div className="flex items-center space-x-3">
+              {todayStatus.status === 'present' && <CheckCircle className="h-6 w-6 text-green-600" />}
+              {todayStatus.status === 'late' && <AlertTriangle className="h-6 w-6 text-orange-600" />}
+              {todayStatus.status === 'not_checked' && <Clock className="h-6 w-6 text-yellow-600" />}
+              <div>
+                <h3 className={`font-medium ${todayStatus.color}`}>Statut du jour</h3>
+                <p className={`text-sm ${todayStatus.color}`}>{todayStatus.message}</p>
               </div>
             </div>
           </div>
 
-          <div className="card hover:shadow-md transition-shadow">
-            <div className="flex items-center">
-              <div className="p-3 bg-yellow-100 rounded-lg">
-                <Clock className="h-6 w-6 text-yellow-600" />
-              </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Retards</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.late_days}</p>
-                <p className="text-xs text-yellow-600">Ce mois-ci</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="card hover:shadow-md transition-shadow">
-            <div className="flex items-center">
-              <div className="p-3 bg-red-100 rounded-lg">
-                <XCircle className="h-6 w-6 text-red-600" />
-              </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Absences</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.absence_days}</p>
-                <p className="text-xs text-red-600">Ce mois-ci</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="card hover:shadow-md transition-shadow">
-            <div className="flex items-center">
-              <div className="p-3 bg-blue-100 rounded-lg">
-                <TrendingUp className="h-6 w-6 text-blue-600" />
-              </div>
-              <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Heures moy.</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.average_hours.toFixed(1)}h</p>
-                <p className="text-xs text-blue-600">Par jour</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Graphique des 7 derniers jours */}
-        <AttendanceChart 
-          data={chartData}
-          title="Activité des 7 derniers jours"
-        />
-
-        {/* Actions rapides améliorées */}
-        <QuickActions />
-      </div>
-
-      {/* Recent Activity */}
-      <div className="card">
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-lg font-semibold text-gray-900">Activité récente</h2>
-          <Calendar className="h-5 w-5 text-gray-400" />
-        </div>
-
-        {attendanceRecords.length === 0 ? (
-          <div className="text-center py-8">
-            <Clock className="mx-auto h-12 w-12 text-gray-400" />
-            <h3 className="mt-2 text-sm font-medium text-gray-900">Aucun pointage</h3>
-            <p className="mt-1 text-sm text-gray-500">
-              Commencez par effectuer votre premier pointage
-            </p>
-            <button 
-              onClick={() => window.location.href = '/checkin'}
-              className="mt-4 btn-primary"
-            >
-              Pointer maintenant
-            </button>
-          </div>
-        ) : (
-          <div className="space-y-4">
-            {attendanceRecords.slice(0, 5).map((record) => (
-              <div key={record.id} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
-                <div className="flex items-center space-x-3">
-                  <div className={`p-2 rounded-full ${
-                    record.type === 'office' ? 'bg-blue-100' : 'bg-purple-100'
-                  }`}>
-                    {record.type === 'office' ? (
-                      <MapPin className={`h-4 w-4 ${
-                        record.type === 'office' ? 'text-blue-600' : 'text-purple-600'
-                      }`} />
-                    ) : (
-                      <Clock className="h-4 w-4 text-purple-600" />
-                    )}
+          {stats && (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              <div className="card hover:shadow-md transition-shadow">
+                <div className="flex items-center">
+                  <div className="p-3 bg-green-100 rounded-lg">
+                    <CheckCircle className="h-6 w-6 text-green-600" />
                   </div>
-                  <div>
-                    <p className="text-sm font-medium text-gray-900">
-                      {record.type === 'office' ? 'Pointage Bureau' : 'Pointage Mission'}
-                    </p>
-                    <p className="text-xs text-gray-500">
-                      {format(new Date(record.date_pointage), 'dd MMMM yyyy', { locale: fr })}
-                      {record.mission_order_number && ` - Mission ${record.mission_order_number}`}
-                    </p>
+                  <div className="ml-4">
+                    <p className="text-sm font-medium text-gray-600">Jours présents</p>
+                    <p className="text-2xl font-bold text-gray-900">{stats.present_days}</p>
+                    <p className="text-xs text-green-600">Ce mois-ci</p>
                   </div>
                 </div>
-                <div className="text-right">
-                  <p className="text-sm font-medium text-gray-900">
-                    {record.heure_arrivee}
-                    {record.heure_depart && ` - ${record.heure_depart}`}
-                  </p>
-                  <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                    record.statut === 'present' 
-                      ? 'bg-green-100 text-green-800'
-                      : record.statut === 'retard'
-                      ? 'bg-yellow-100 text-yellow-800'
-                      : 'bg-red-100 text-red-800'
-                  }`}>
-                    {record.statut}
-                  </span>
+              </div>
+
+              <div className="card hover:shadow-md transition-shadow">
+                <div className="flex items-center">
+                  <div className="p-3 bg-yellow-100 rounded-lg">
+                    <Clock className="h-6 w-6 text-yellow-600" />
+                  </div>
+                  <div className="ml-4">
+                    <p className="text-sm font-medium text-gray-600">Retards</p>
+                    <p className="text-2xl font-bold text-gray-900">{stats.late_days}</p>
+                    <p className="text-xs text-yellow-600">Ce mois-ci</p>
+                  </div>
                 </div>
               </div>
-            ))}
-            
-            {attendanceRecords.length > 5 && (
-              <div className="text-center pt-4">
-                <button 
-                  onClick={() => window.location.href = '/history'}
-                  className="text-primary-600 hover:text-primary-700 text-sm font-medium"
-                >
-                  Voir tous les pointages →
+
+              <div className="card hover:shadow-md transition-shadow">
+                <div className="flex items-center">
+                  <div className="p-3 bg-red-100 rounded-lg">
+                    <XCircle className="h-6 w-6 text-red-600" />
+                  </div>
+                  <div className="ml-4">
+                    <p className="text-sm font-medium text-gray-600">Absences</p>
+                    <p className="text-2xl font-bold text-gray-900">{stats.absence_days}</p>
+                    <p className="text-xs text-red-600">Ce mois-ci</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="card hover:shadow-md transition-shadow">
+                <div className="flex items-center">
+                  <div className="p-3 bg-blue-100 rounded-lg">
+                    <TrendingUp className="h-6 w-6 text-blue-600" />
+                  </div>
+                  <div className="ml-4">
+                    <p className="text-sm font-medium text-gray-600">Heures moy.</p>
+                    <p className="text-2xl font-bold text-gray-900">{stats.average_hours.toFixed(1)}h</p>
+                    <p className="text-xs text-blue-600">Par jour</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <AttendanceChart data={chartData} title="Activité des 7 derniers jours" />
+
+          <div className="card">
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-lg font-semibold text-gray-900">Activité récente</h2>
+              <Calendar className="h-5 w-5 text-gray-400" />
+            </div>
+
+            {attendanceRecords.length === 0 ? (
+              <div className="text-center py-8">
+                <Clock className="mx-auto h-12 w-12 text-gray-400" />
+                <h3 className="mt-2 text-sm font-medium text-gray-900">Aucun pointage</h3>
+                <p className="mt-1 text-sm text-gray-500">Commencez par effectuer votre premier pointage</p>
+                <button onClick={() => (window.location.href = '/checkin')} className="mt-4 btn-primary">
+                  Pointer maintenant
                 </button>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {attendanceRecords.slice(0, 5).map((record) => (
+                  <div
+                    key={record.id}
+                    className="flex items-center justify-between p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+                  >
+                    <div className="flex items-center space-x-3">
+                      <div className={`p-2 rounded-full ${record.type === 'office' ? 'bg-blue-100' : 'bg-purple-100'}`}>
+                        {record.type === 'office' ? (
+                          <MapPin className={`h-4 w-4 ${record.type === 'office' ? 'text-blue-600' : 'text-purple-600'}`} />
+                        ) : (
+                          <Clock className="h-4 w-4 text-purple-600" />
+                        )}
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-gray-900">
+                          {record.type === 'office' ? 'Pointage Bureau' : 'Pointage Mission'}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {format(new Date(record.date_pointage), 'dd MMMM yyyy', { locale: fr })}
+                          {record.mission_order_number && ` - Mission ${record.mission_order_number}`}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-sm font-medium text-gray-900">
+                        {record.heure_arrivee}
+                        {record.heure_depart && ` - ${record.heure_depart}`}
+                      </p>
+                      <span
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          record.statut === 'present'
+                            ? 'bg-green-100 text-green-800'
+                            : record.statut === 'retard'
+                            ? 'bg-yellow-100 text-yellow-800'
+                            : 'bg-red-100 text-red-800'
+                        }`}
+                      >
+                        {record.statut}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+
+                {attendanceRecords.length > 5 && (
+                  <div className="text-center pt-4">
+                    <button
+                      onClick={() => (window.location.href = '/history')}
+                      className="text-primary-600 hover:text-primary-700 text-sm font-medium"
+                    >
+                      Voir tous les pointages →
+                    </button>
+                  </div>
+                )}
               </div>
             )}
           </div>
-        )}
-      </div>
+        </>
+      )}
+
+      {widgets.reminders && <RemindersWidget />}
+
+      {widgets.quickActions && <QuickActions />}
     </div>
   )
 }

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | false | null)[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/utils/roleStyles.ts
+++ b/src/utils/roleStyles.ts
@@ -1,0 +1,18 @@
+import { Crown, Shield, Users, Briefcase, UserCheck, Eye, User } from 'lucide-react'
+
+export const roleStyles = {
+  superadmin: { label: 'Super Admin', icon: Crown, color: 'text-red-700', bg: 'bg-red-100' },
+  admin_rh: { label: 'Admin RH', icon: Shield, color: 'text-blue-700', bg: 'bg-blue-100' },
+  chef_service: { label: 'Chef Service', icon: Users, color: 'text-purple-700', bg: 'bg-purple-100' },
+  chef_projet: { label: 'Chef Projet', icon: Briefcase, color: 'text-amber-700', bg: 'bg-amber-100' },
+  manager: { label: 'Manager', icon: UserCheck, color: 'text-green-700', bg: 'bg-green-100' },
+  auditeur: { label: 'Auditeur', icon: Eye, color: 'text-indigo-700', bg: 'bg-indigo-100' },
+  employee: { label: 'Employé', icon: User, color: 'text-gray-700', bg: 'bg-gray-100' }
+} as const
+
+export type RoleKey = keyof typeof roleStyles
+
+export function getRoleStyle(role?: string) {
+  if (!role) return roleStyles.employee
+  return roleStyles[role as RoleKey] || roleStyles.employee
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -8,25 +9,72 @@ export default {
     extend: {
       colors: {
         border: '#e5e7eb',
-        background: '#f9fafb',
-        foreground: '#111827',
+        background: 'var(--color-background, #f9fafb)',
+        foreground: 'var(--color-foreground, #111827)',
         primary: {
-          50: '#eff6ff',
-          100: '#dbeafe',
-          200: '#bfdbfe',
-          300: '#93c5fd',
-          400: '#60a5fa',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          800: '#1e40af',
-          900: '#1e3a8a',
+          50: 'var(--color-primary-50, #eff6ff)',
+          100: 'var(--color-primary-100, #dbeafe)',
+          200: 'var(--color-primary-200, #bfdbfe)',
+          300: 'var(--color-primary-300, #93c5fd)',
+          400: 'var(--color-primary-400, #60a5fa)',
+          500: 'var(--color-primary-500, #3b82f6)',
+          600: 'var(--color-primary-600, #2563eb)',
+          700: 'var(--color-primary-700, #1d4ed8)',
+          800: 'var(--color-primary-800, #1e40af)',
+          900: 'var(--color-primary-900, #1e3a8a)',
+        },
+        accent: {
+          50: '#ecfdf5',
+          100: '#d1fae5',
+          200: '#a7f3d0',
+          300: '#6ee7b7',
+          400: '#34d399',
+          500: '#10b981',
+          600: '#059669',
+          700: '#047857',
+          800: '#065f46',
+          900: '#064e3b',
         },
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
       },
+      fontSize: {
+        h1: ['2.25rem', { lineHeight: '2.5rem', fontWeight: '700' }],
+        h2: ['1.875rem', { lineHeight: '2.25rem', fontWeight: '600' }],
+        h3: ['1.5rem', { lineHeight: '2rem', fontWeight: '600' }],
+        h4: ['1.25rem', { lineHeight: '1.75rem', fontWeight: '500' }],
+        subtitle: ['1rem', { lineHeight: '1.5rem', fontWeight: '500' }],
+        caption: ['0.75rem', { lineHeight: '1rem' }],
+      },
+      spacing: {
+        13: '3.25rem',
+        15: '3.75rem',
+        18: '4.5rem',
+        22: '5.5rem',
+        26: '6.5rem',
+      },
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
+        },
+        'slide-in': {
+          from: { transform: 'translateY(0.5rem)', opacity: '0' },
+          to: { transform: 'translateY(0)', opacity: '1' },
+        },
+        'scale-in': {
+          from: { transform: 'scale(0.95)', opacity: '0' },
+          to: { transform: 'scale(1)', opacity: '1' },
+        },
+      },
+      animation: {
+        'fade-in': 'fade-in 0.2s ease-out',
+        'slide-in': 'slide-in 0.2s ease-out',
+        'scale-in': 'scale-in 0.2s ease-out',
+      },
     },
   },
   plugins: [],
 }
+


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode and CSS-variable color tokens for per-tenant customization
- introduce ThemeContext with persistent theme & density preferences
- add header toggle to switch light/dark modes
- create reusable Button, Badge and Card components with color/size variants and keyboard-friendly focus styles
- replace placeholder layout with modular Sidebar and Header
- animate modal transitions and toast arrivals
- show table skeletons while loading employee data
- replace demo-account DOM hacks with role selector, password strength meter and 2FA progress feedback
- enrich typography, spacing and accent palette for clearer visual hierarchy
- enhance accessibility with ARIA live regions for toasts & notifications and global focus-visible outlines
- integrate Recharts for interactive attendance charts
- upgrade DataTable with sorting, filters, pagination and optional card view
- add configurable dashboard widgets for presence weather, reminders and quick actions with role-based colors and icons
- fix CheckIn import path and button base styles to avoid dev build errors

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ef4f9288332afa9594f4bd53924