### PR TITLE
feat: mission respond endpoint and API client

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -949,6 +949,14 @@ export const missionService = {
       throw error
     }
   },
+  respond: async (missionId: number, status: 'accepted' | 'declined') => {
+    try {
+      return await api.post(`/missions/${missionId}/respond`, { status })
+    } catch (error) {
+      console.error('Respond mission error:', error)
+      throw error
+    }
+  },
 
 }
 

--- a/src/services/missionService.test.ts
+++ b/src/services/missionService.test.ts
@@ -1,0 +1,18 @@
+import { missionService, api } from './api'
+
+describe('missionService.respond', () => {
+  it('sends accepted status', async () => {
+    const mock = jest.spyOn(api, 'post').mockResolvedValue({} as any)
+    await missionService.respond(1, 'accepted')
+    expect(mock).toHaveBeenCalledWith('/missions/1/respond', { status: 'accepted' })
+    mock.mockRestore()
+  })
+
+  it('sends declined status', async () => {
+    const mock = jest.spyOn(api, 'post').mockResolvedValue({} as any)
+    await missionService.respond(2, 'declined')
+    expect(mock).toHaveBeenCalledWith('/missions/2/respond', { status: 'declined' })
+    mock.mockRestore()
+  })
+})
+


### PR DESCRIPTION
## Summary
- allow users to accept or decline mission assignments
- expose missionService.respond to consume the new API
- test mission response acceptance/decline on backend and service layer

## Testing
- `pytest backend/tests/test_missions.py::test_mission_user_accepts_assignment backend/tests/test_missions.py::test_mission_user_declines_assignment -q`
- `npm test -- missionService.test.ts` *(fails: jest not found; npm install 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68aa549e22988332a89c3b9bb80191da