### PR TITLE
feat: handle mission acceptance and check-in selection

### DIFF
--- a/src/components/attendance/MissionCheckIn.test.tsx
+++ b/src/components/attendance/MissionCheckIn.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import MissionCheckIn from './MissionCheckIn'
+
+jest.mock('../../services/api', () => ({
+  missionService: {
+    getActiveMissions: jest.fn()
+  },
+  attendanceService: {
+    checkInMission: jest.fn()
+  }
+}))
+
+const mockGeolocation = () => {
+  const mockGetCurrentPosition = jest.fn().mockImplementation((success) => {
+    success({ coords: { latitude: 1, longitude: 2 } })
+  })
+  // @ts-ignore
+  global.navigator.geolocation = { getCurrentPosition: mockGetCurrentPosition }
+}
+
+test('check-in with accepted mission', async () => {
+  const { missionService, attendanceService } = require('../../services/api')
+  missionService.getActiveMissions.mockResolvedValue({ data: { missions: [
+    { id: 1, order_number: 'M1', status: 'accepted' }
+  ] } })
+  attendanceService.checkInMission.mockResolvedValue({})
+  mockGeolocation()
+
+  render(<MissionCheckIn />)
+  const select = await screen.findByLabelText('Mission')
+  fireEvent.change(select, { target: { value: 'M1' } })
+  fireEvent.click(screen.getByText('Pointer en Mission'))
+  await waitFor(() => expect(attendanceService.checkInMission).toHaveBeenCalled())
+})
+
+test('prevents check-in for non accepted mission', async () => {
+  const { missionService, attendanceService } = require('../../services/api')
+  missionService.getActiveMissions.mockResolvedValue({ data: { missions: [
+    { id: 1, order_number: 'M1', status: 'pending' }
+  ] } })
+  mockGeolocation()
+
+  render(<MissionCheckIn />)
+  const select = await screen.findByLabelText('Mission')
+  fireEvent.change(select, { target: { value: 'M1' } })
+  fireEvent.click(screen.getByText('Pointer en Mission'))
+  await waitFor(() => expect(attendanceService.checkInMission).not.toHaveBeenCalled())
+})

--- a/src/pages/Missions.test.tsx
+++ b/src/pages/Missions.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import Missions from './Missions'
+
+jest.mock('../services/api', () => ({
+  missionService: {
+    getMissions: jest.fn().mockResolvedValue({ data: { missions: [
+      { id: 1, order_number: 'M1', title: 'Test', start_date: null, end_date: null, status: 'pending' }
+    ] } }),
+    createMission: jest.fn(),
+    respond: jest.fn().mockResolvedValue({})
+  },
+  adminService: {
+    getEmployees: jest.fn().mockResolvedValue({ data: { employees: [] } })
+  }
+}))
+
+test('accept mission triggers respond', async () => {
+  const { missionService } = require('../services/api')
+  render(<Missions />)
+  const acceptBtn = await screen.findByText('Accepter')
+  fireEvent.click(acceptBtn)
+  await waitFor(() => expect(missionService.respond).toHaveBeenCalledWith(1, 'accepted'))
+})
+
+test('decline mission triggers respond', async () => {
+  const { missionService } = require('../services/api')
+  render(<Missions />)
+  const declineBtn = await screen.findByText('Refuser')
+  fireEvent.click(declineBtn)
+  await waitFor(() => expect(missionService.respond).toHaveBeenCalledWith(1, 'declined'))
+})

--- a/src/pages/Missions.tsx
+++ b/src/pages/Missions.tsx
@@ -66,6 +66,16 @@ export default function Missions() {
     }
   }
 
+  const handleRespond = async (id: number, status: 'accepted' | 'declined') => {
+    try {
+      await missionService.respond(id, status)
+      toast.success(status === 'accepted' ? 'Mission acceptée' : 'Mission refusée')
+      fetchMissions()
+    } catch (error) {
+      toast.error('Erreur lors de la réponse')
+    }
+  }
+
   return (
     <div className="space-y-6 max-w-3xl mx-auto">
       <h1 className="text-2xl font-bold">Missions</h1>
@@ -159,7 +169,25 @@ export default function Missions() {
                   <td className="px-4 py-2">{m.title}</td>
                   <td className="px-4 py-2">{m.start_date || '-'}</td>
                   <td className="px-4 py-2">{m.end_date || '-'}</td>
-                  <td className="px-4 py-2">{m.status}</td>
+                  <td className="px-4 py-2">
+                    {m.status}
+                    {m.status === 'pending' && (
+                      <div className="mt-2 space-x-2">
+                        <button
+                          onClick={() => handleRespond(m.id, 'accepted')}
+                          className="btn-primary text-xs"
+                        >
+                          Accepter
+                        </button>
+                        <button
+                          onClick={() => handleRespond(m.id, 'declined')}
+                          className="btn-secondary text-xs"
+                        >
+                          Refuser
+                        </button>
+                      </div>
+                    )}
+                  </td>
                 </tr>
               ))}
               {missions.length === 0 && (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -949,6 +949,14 @@ export const missionService = {
       throw error
     }
   },
+  getActiveMissions: async () => {
+    try {
+      return await api.get('/missions/active')
+    } catch (error) {
+      console.error('Get active missions error:', error)
+      throw error
+    }
+  },
   respond: async (missionId: number, status: 'accepted' | 'declined') => {
     try {
       return await api.post(`/missions/${missionId}/respond`, { status })


### PR DESCRIPTION
## Summary
- show mission status and allow accepting or declining
- select accepted missions for check-in
- cover mission flow with tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-native)*
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5648b68c8332a7aeefed01b96af4