### PR TITLE
feat: validate firebase env config

### DIFF
--- a/src/firebaseInit.ts
+++ b/src/firebaseInit.ts
@@ -20,8 +20,32 @@ const VAPID_KEY = import.meta.env.VITE_FIREBASE_VAPID_KEY;
 
 let app: FirebaseApp | null = null;
 
+const validateFirebaseConfig = (): boolean => {
+  const missingKeys = Object.entries(firebaseConfig)
+    .filter(([, value]) => value === undefined || value === "")
+    .map(([key]) => key);
+
+  if (missingKeys.length > 0) {
+    missingKeys.forEach((key) => {
+      console.warn(`Firebase config missing value for ${key}`);
+    });
+
+    if (import.meta.env.DEV) {
+      throw new Error(`Missing Firebase config values: ${missingKeys.join(', ')}`);
+    }
+
+    return false;
+  }
+
+  return true;
+};
+
 export const initializeFirebaseApp = () => {
   if (app) return app;
+  if (!validateFirebaseConfig()) {
+    console.warn('Firebase initialization skipped due to missing configuration.');
+    return null;
+  }
   try {
     app = initializeApp(firebaseConfig);
     console.log("Firebase initialized successfully");


### PR DESCRIPTION
## Summary
- warn about missing Firebase env vars and skip initialization

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab879113cc8332a6547bb8dd6fe302