### PR TITLE
feat: enable React Router v7 future flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,7 +135,7 @@ function App() {
 
   return (
     <AuthProvider>
-      <Router>
+      <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Routes>
           <Route path="/login" element={<Login />} />
           


### PR DESCRIPTION
## Summary
- enable React Router v7 future flags for BrowserRouter

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab879a25f083328d2935643cc5587b