### PR TITLE
Add geofencing support for missions

### DIFF
--- a/backend/models/mission.py
+++ b/backend/models/mission.py
@@ -19,6 +19,9 @@ class Mission(db.Model):
     status = db.Column(db.String(20), default='planned', nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    latitude = db.Column(db.Float, nullable=True)
+    longitude = db.Column(db.Float, nullable=True)
+    radius = db.Column(db.Integer, nullable=True)
 
     company = db.relationship('Company', backref='missions', lazy=True)
     users = db.relationship('MissionUser', back_populates='mission', lazy=True, cascade='all, delete-orphan')
@@ -35,6 +38,9 @@ class Mission(db.Model):
             'status': self.status,
             'created_at': self.created_at.isoformat(),
             'updated_at': self.updated_at.isoformat(),
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'radius': self.radius,
             'users': [mu.to_dict() for mu in self.users]
         }
 

--- a/backend/routes/mission_routes.py
+++ b/backend/routes/mission_routes.py
@@ -49,6 +49,9 @@ def create_mission():
             start_date=data.get('start_date'),
             end_date=data.get('end_date'),
             status=data.get('status', 'planned'),
+            latitude=data.get('latitude'),
+            longitude=data.get('longitude'),
+            radius=data.get('radius'),
         )
         db.session.add(mission)
         db.session.flush()
@@ -131,7 +134,7 @@ def update_mission(mission_id):
         old_values = mission.to_dict() # Capture state before changes
         data = request.get_json() or {}
 
-        for field in ['title', 'description', 'start_date', 'end_date', 'status']:
+        for field in ['title', 'description', 'start_date', 'end_date', 'status', 'latitude', 'longitude', 'radius']:
             if field in data:
                 setattr(mission, field, data[field])
 


### PR DESCRIPTION
## Summary
- add latitude, longitude, and radius to missions
- enforce mission geofencing during attendance check-in
- allow mission creation and updates to manage location fields
- test mission check-ins for inside/outside radius

## Testing
- `pytest backend/tests/test_attendance.py::test_mission_checkin_accepts_within_radius backend/tests/test_attendance.py::test_mission_checkin_rejects_outside_radius`
- `pytest backend/tests/test_attendance.py::test_office_checkin`
- `pytest backend/tests/test_missions.py`


------
https://chatgpt.com/codex/tasks/task_e_68acddebd47883328af81d5212ff72b3