### PR TITLE
feat: add geolocation accuracy limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ JWT_SECRET_KEY=your-jwt-secret-key-here
 DATABASE_URL=sqlite:///instance/pointflex.db
 CORS_ORIGINS=http://localhost,https://yourdomain.com
 REDIS_URL=redis://localhost:6379/0
+GEOLOCATION_MAX_ACCURACY=100  # Précision GPS maximale (en mètres)
 STRIPE_API_KEY=your-stripe-key
 STRIPE_WEBHOOK_SECRET=your-webhook-secret
 STRIPE_PRICE_MAP={"price_basic_monthly_test":{"name":"basic","max_employees":10,"amount_eur":10,"interval_months":1}}

--- a/backend/config.py
+++ b/backend/config.py
@@ -51,6 +51,9 @@ class Config:
     # Limites système
     MAX_COMPANIES = 1000
     MAX_USERS_PER_COMPANY = 999
+
+    # Géolocalisation
+    GEOLOCATION_MAX_ACCURACY = int(os.environ.get('GEOLOCATION_MAX_ACCURACY') or 100)
     
     # Sécurité des mots de passe
     PASSWORD_MIN_LENGTH = 8

--- a/backend/models/company.py
+++ b/backend/models/company.py
@@ -3,6 +3,7 @@ Modèle Company - Gestion des entreprises
 """
 
 from backend.database import db
+from backend.config import Config
 from datetime import datetime, timedelta
 
 class Company(db.Model):
@@ -54,6 +55,8 @@ class Company(db.Model):
     office_longitude = db.Column(db.Float, default=2.3522)
     # Rayon par défaut autorisé autour du siège (en mètres)
     office_radius = db.Column(db.Integer, default=200)
+    # Précision maximale de la géolocalisation en mètres
+    geolocation_max_accuracy = db.Column(db.Integer, default=Config.GEOLOCATION_MAX_ACCURACY)
     work_start_time = db.Column(db.Time, default=datetime.strptime('09:00', '%H:%M').time())
     late_threshold = db.Column(db.Integer, default=15)  # minutes
     # Minutes de tolérance pour l'égalisation de l'heure d'arrivée
@@ -282,6 +285,7 @@ class Company(db.Model):
                 'office_latitude': self.office_latitude,
                 'office_longitude': self.office_longitude,
                 'office_radius': self.office_radius,
+                'geolocation_max_accuracy': self.geolocation_max_accuracy,
                 'work_start_time': self.work_start_time.strftime('%H:%M') if self.work_start_time else None,
                 'late_threshold': self.late_threshold,
                 'equalization_threshold': self.equalization_threshold,

--- a/backend/models/office.py
+++ b/backend/models/office.py
@@ -25,6 +25,8 @@ class Office(db.Model):
     longitude = db.Column(db.Float, nullable=False)
     # Rayon autorisé pour le pointage en mètres
     radius = db.Column(db.Integer, default=200, nullable=False)
+    # Précision maximale de la géolocalisation pour ce bureau (en mètres)
+    geolocation_max_accuracy = db.Column(db.Integer, nullable=True)
     
     # Informations complémentaires
     timezone = db.Column(db.String(50), default='Europe/Paris', nullable=False)
@@ -66,6 +68,7 @@ class Office(db.Model):
             'latitude': self.latitude,
             'longitude': self.longitude,
             'radius': self.radius,
+            'geolocation_max_accuracy': self.geolocation_max_accuracy,
             'timezone': self.timezone,
             'capacity': self.capacity,
             'amenities': amenities_list,

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -1109,7 +1109,7 @@ def update_company_settings():
         
         # Mettre à jour les champs
         updatable_fields = [
-            'office_latitude', 'office_longitude', 'office_radius',
+            'office_latitude', 'office_longitude', 'office_radius', 'geolocation_max_accuracy',
             'work_start_time', 'late_threshold', 'logo_url', 'theme_color'
         ]
         

--- a/backend/routes/qr_attendance_routes.py
+++ b/backend/routes/qr_attendance_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, current_app
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from datetime import datetime, timedelta
 import secrets
@@ -131,6 +131,24 @@ def qr_checkin():
     office = Office.query.get(token_data['office_id'])
     if not office:
         return jsonify({"success": False, "message": "Bureau non trouvé"}), 404
+
+    if location_data:
+        if location_data.get('accuracy') is None:
+            return jsonify({"success": False, "message": "Précision GPS requise"}), 400
+        max_accuracy = current_app.config.get('GEOLOCATION_MAX_ACCURACY', 100)
+        company = office.company
+        if company and company.geolocation_max_accuracy is not None:
+            max_accuracy = company.geolocation_max_accuracy
+        if office.geolocation_max_accuracy is not None:
+            max_accuracy = office.geolocation_max_accuracy
+        if location_data['accuracy'] > max_accuracy:
+            return jsonify({
+                "success": False,
+                "message": (
+                    f"Précision de localisation insuffisante ({int(location_data['accuracy'])}m). "
+                    f"Maximum autorisé: {max_accuracy}m"
+                ),
+            }), 400
     
     # Déterminer le type de pointage (entrée ou sortie)
     pointage_type = determine_pointage_type(user_id)

--- a/backend/tests/test_attendance.py
+++ b/backend/tests/test_attendance.py
@@ -7,6 +7,12 @@ def login_employee(client):
     return resp.get_json()['token']
 
 
+def login_admin(client):
+    resp = client.post('/api/auth/login', json={'email': 'admin@pointflex.com', 'password': 'admin123'})
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
 def test_office_checkin(client):
     token = login_employee(client)
     headers = {'Authorization': f'Bearer {token}'}
@@ -16,6 +22,63 @@ def test_office_checkin(client):
     body = resp.get_json()
     assert body['pointage']['type'] == 'office'
     assert 'is_equalized' in body['pointage']
+
+
+def test_office_checkin_respects_company_accuracy(client):
+    token = login_employee(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    from backend.models.company import Company
+    from backend.database import db
+    with client.application.app_context():
+        company = Company.query.first()
+        company.geolocation_max_accuracy = 10
+        db.session.commit()
+    resp = client.post(
+        '/api/attendance/checkin/office',
+        json={'coordinates': {'latitude': 48.8566, 'longitude': 2.3522, 'accuracy': 50}},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_qr_checkin_respects_office_accuracy(client):
+    admin_token = login_admin(client)
+    employee_token = login_employee(client)
+    from backend.models.company import Company
+    from backend.models.office import Office
+    from backend.database import db
+    with client.application.app_context():
+        company = Company.query.first()
+        office = Office(
+            company_id=company.id,
+            name='HQ',
+            address='A',
+            city='Paris',
+            country='FR',
+            latitude=48.8566,
+            longitude=2.3522,
+            radius=200,
+            geolocation_max_accuracy=5,
+        )
+        db.session.add(office)
+        db.session.commit()
+        office_id = office.id
+    admin_headers = {'Authorization': f'Bearer {admin_token}'}
+    resp = client.post(
+        '/api/attendance/generate-qr-token',
+        json={'office_id': office_id},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    token = resp.get_json()['token']
+    headers = {'Authorization': f'Bearer {employee_token}'}
+    loc = {'latitude': 48.8566, 'longitude': 2.3522, 'accuracy': 10}
+    resp = client.post(
+        '/api/attendance/qr-checkin',
+        json={'token': token, 'location': loc},
+        headers=headers,
+    )
+    assert resp.status_code == 400
 
 
 def test_mission_checkin_requires_acceptance(client):
@@ -90,7 +153,11 @@ def test_multiple_checkins_same_day(client):
 def test_get_attendance_stats(client):
     token = login_employee(client)
     headers = {'Authorization': f'Bearer {token}'}
-    client.post('/api/attendance/checkin/office', json={'coordinates': {'latitude': 48.8566, 'longitude': 2.3522}}, headers=headers)
+    client.post(
+        '/api/attendance/checkin/office',
+        json={'coordinates': {'latitude': 48.8566, 'longitude': 2.3522, 'accuracy': 5}},
+        headers=headers,
+    )
     resp = client.get('/api/attendance/stats', headers=headers)
     assert resp.status_code == 200
     data = resp.get_json()


### PR DESCRIPTION
## Summary
- add configurable `GEOLOCATION_MAX_ACCURACY`
- allow company and office overrides for geolocation precision
- document geolocation accuracy setting and cover with tests

## Testing
- `pytest tests/test_attendance.py`
- `pytest` *(fails: Table 'users' is already defined for this MetaData instance)*

------
https://chatgpt.com/codex/tasks/task_e_68acddef81d88332a212b1c38d9f9f30