### PR TITLE
Add geolocation_max_accuracy column migration

### DIFF
--- a/backend/migrations/versions/20240312_add_geolocation_max_accuracy_to_companies.py
+++ b/backend/migrations/versions/20240312_add_geolocation_max_accuracy_to_companies.py
@@ -1,0 +1,20 @@
+"""Add geolocation_max_accuracy to companies"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240312_add_geolocation_max_accuracy_to_companies'
+down_revision = '20240218_add_mission_id_to_pointages'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column(
+        'companies',
+        sa.Column('geolocation_max_accuracy', sa.Integer(), server_default='100', nullable=True)
+    )
+    op.execute("UPDATE companies SET geolocation_max_accuracy = 100 WHERE geolocation_max_accuracy IS NULL")
+    op.alter_column('companies', 'geolocation_max_accuracy', server_default=None)
+
+def downgrade():
+    op.drop_column('companies', 'geolocation_max_accuracy')


### PR DESCRIPTION
## Summary
- add Alembic migration to introduce `geolocation_max_accuracy` on `companies`
- populate existing records with default value

## Testing
- `flask db upgrade` *(fails: No such command 'db')*
- `python - <<'PY' ...` (login and GET superadmin endpoints -> 200)
- `pytest backend/tests/test_health.py` *(fails: ModuleNotFoundError: No module named 'cryptography.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_68add24c36908332aca1a42d818cb0c5